### PR TITLE
docs(config): document slow-query body limit

### DIFF
--- a/content/cn/docs/config/config-guide.md
+++ b/content/cn/docs/config/config-guide.md
@@ -204,6 +204,8 @@ server.role=master
 
 # slow query log
 log.slow_query_threshold=1000
+# bytes of request body recorded as-is (may contain sensitive literals), 0 to disable
+log.slow_query_body_limit=512
 
 # jvm(in-heap) memory usage monitor, set 1 to disable it
 memory_monitor.threshold=0.85

--- a/content/cn/docs/config/config-option.md
+++ b/content/cn/docs/config/config-option.md
@@ -53,6 +53,7 @@ weight: 2
 | memory_monitor.threshold           | 0.85                                             | The threshold of JVM(in-heap) memory usage monitoring , 1 means disabling this function.                                                                                                                                                                                |
 | memory_monitor.period              | 2000                                             | The period in ms of JVM(in-heap) memory usage monitoring.                                                                                                                                                     |
 | log.slow_query_threshold           | 1000                                             | Slow query log threshold in milliseconds, 0 means disabled.                                                                                                                                                   |
+| log.slow_query_body_limit          | 512                                              | 慢查询日志记录的请求体最大字节数，0 表示不记录。记录的前缀可能包含敏感的 Gremlin 或 Cypher 字面量。                                                                                                              |
 
 ### PD/Meta 配置项 (分布式模式)
 
@@ -340,4 +341,3 @@ weight: 2
 > - `jdbc.url=jdbc:postgresql://localhost:5432/`
 
 </details>
-

--- a/content/en/docs/config/config-guide.md
+++ b/content/en/docs/config/config-guide.md
@@ -202,6 +202,8 @@ server.role=master
 
 # slow query log
 log.slow_query_threshold=1000
+# bytes of request body recorded as-is (may contain sensitive literals), 0 to disable
+log.slow_query_body_limit=512
 
 # jvm(in-heap) memory usage monitor, set 1 to disable it
 memory_monitor.threshold=0.85

--- a/content/en/docs/config/config-option.md
+++ b/content/en/docs/config/config-option.md
@@ -53,6 +53,7 @@ Corresponding configuration file `rest-server.properties`
 | memory_monitor.threshold           | 0.85                                             | The threshold of JVM(in-heap) memory usage monitoring , 1 means disabling this function.                                                                                                                      |
 | memory_monitor.period              | 2000                                             | The period in ms of JVM(in-heap) memory usage monitoring.                                                                                                                                                     |
 | log.slow_query_threshold           | 1000                                             | Slow query log threshold in milliseconds, 0 means disabled.                                                                                                                                                   |
+| log.slow_query_body_limit          | 512                                              | Maximum bytes of a request body recorded in the slow query log, 0 means disabled. The recorded prefix may contain sensitive Gremlin or Cypher literals.                                                       |
 
 ### PD/Meta Config Options (Distributed Mode)
 
@@ -319,4 +320,3 @@ Other options are consistent with the MySQL backend.
 > - `jdbc.url=jdbc:postgresql://localhost:5432/`
 
 </details>
-


### PR DESCRIPTION
## Before → After

- Before: the REST configuration docs listed only `log.slow_query_threshold`.
- After: the English and Chinese config guide and option reference also document `log.slow_query_body_limit`, its 512-byte default, and `0` disable value.

Related to apache/hugegraph#3177.

## Verification

- `git diff --check`
- Hugo parsed the updated content; the local build then stopped at the existing missing `postcss-cli` dependency.