### PR TITLE
doc(toolchain): sync spark-connector with master

### DIFF
--- a/content/cn/docs/quickstart/toolchain/hugegraph-spark-connector.md
+++ b/content/cn/docs/quickstart/toolchain/hugegraph-spark-connector.md
@@ -8,12 +8,14 @@ weight: 4
 
 HugeGraph-Spark-Connector 使用 Spark DataFrame API 将批量数据写入 HugeGraph。当前实现提供顶点和边的写入器。
 
+目前尚未实现从 HugeGraph 读取数据：表只实现了 `SupportsWrite`，因此不支持 `spark.read.format(...)`。连接器支持 `CUSTOMIZE` 和 `PRIMARY_KEY` 两种顶点 id 策略，`AUTOMATIC` 策略会被拒绝。
+
 ### 2 环境要求
 
 - Java 8+
 - Maven 3.6+
-- Spark 3.x
-- Scala 2.12
+- Spark 3.2.x（模块基于 Spark 3.2.2 编译，依赖范围为 `provided`，因此需要由 Spark 运行环境提供 Spark 的 jar）
+- Scala 2.12（基于 Scala 2.12.11 编译）
 
 ### 3 编译
 
@@ -33,6 +35,8 @@ mvn clean package -pl hugegraph-spark-connector -am -DskipTests -ntp
 mvn clean package -pl hugegraph-spark-connector -am -ntp
 ```
 
+两条命令都会在 `hugegraph-spark-connector/target/hugegraph-spark-connector-${revision}-jar-with-dependencies.jar` 生成一个包含依赖的 jar（不包含 Spark 本身）。如果不通过 Maven 管理依赖，可以把它传给 `spark-submit --jars`。
+
 ### 4 使用方法
 
 先在 `pom.xml` 中添加依赖，并将 `${revision}` 换成实际使用的发布版本：
@@ -44,6 +48,8 @@ mvn clean package -pl hugegraph-spark-connector -am -ntp
     <version>${revision}</version>
 </dependency>
 ```
+
+`format` 必须写完整类名 `org.apache.hugegraph.spark.connector.DataSource`，连接器没有通过 Spark 的 `DataSourceRegister` 服务注册短名称。当 HugeGraphServer 开启鉴权时，需要在下面的示例中加上 `.option("username", ...)` 和 `.option("token", ...)`。
 
 #### 4.1 Schema 定义示例
 
@@ -138,7 +144,60 @@ df.write
   .save()
 ```
 
+#### 4.4 写入 PRIMARY_KEY id 策略的顶点（Scala）
+
+对于使用 `primaryKeys(...)` 的顶点标签，不要设置 `id` 选项：id 由主键列拼接生成。不属于 schema 的列可以通过 `ignored-fields` 丢弃。
+
+```scala
+val df = sparkSession.createDataFrame(Seq(
+  Tuple4("lop", "java", 328L, "ISBN978-7-107-18618-5"),
+  Tuple4("ripple", "python", 199L, "ISBN978-7-100-13678-5"),
+)).toDF("name", "lang", "price", "ISBN")
+
+df.write
+  .format("org.apache.hugegraph.spark.connector.DataSource")
+  .option("host", "127.0.0.1")
+  .option("port", "8080")
+  .option("graph", "hugegraph")
+  .option("data-type", "vertex")
+  .option("label", "software")
+  .option("ignored-fields", "ISBN")
+  .option("batch-size", 2)
+  .mode(SaveMode.Overwrite)
+  .save()
+```
+
+#### 4.5 写入两端 id 策略不同的边（Scala）
+
+`source-name` 和 `target-name` 各自遵循对应顶点标签的 id 策略。下面的例子中，`person` 使用自定义字符串 id（一列），`software` 使用主键（其 `name` 列）：
+
+```scala
+val df = sparkSession.createDataFrame(Seq(
+  Tuple4("marko", "lop", "20171210", 0.5),
+  Tuple4("Josh", "lop", "20091111", 0.4),
+  Tuple4("peter", "ripple", "20171210", 1.0),
+  Tuple4("vadas", "lop", "20171210", 0.2)
+)).toDF("source", "name", "date", "weight")
+
+df.write
+  .format("org.apache.hugegraph.spark.connector.DataSource")
+  .option("host", "127.0.0.1")
+  .option("port", "8080")
+  .option("graph", "hugegraph")
+  .option("data-type", "edge")
+  .option("label", "created")
+  .option("source-name", "source") // 自定义 id
+  .option("target-name", "name")   // 主键
+  .option("batch-size", 2)
+  .mode(SaveMode.Overwrite)
+  .save()
+```
+
+关于保存模式：`SaveMode.Overwrite` 和 `SaveMode.Append` 都只是插入数据，overwrite 路径不会先删除图中已有的数据。
+
 ### 5 配置参数
+
+选项名匹配时不区分大小写并会去掉首尾空格。`data-type` 和 `label` 必填；当 `data-type` 为 `edge` 时 `source-name` 和 `target-name` 必填；其余选项都有默认值。
 
 #### 5.1 客户端配置
 
@@ -146,17 +205,17 @@ df.write
 
 | 参数                   | 默认值        | 说明                                                    |
 |----------------------|------------|-------------------------------------------------------|
-| `host`               | `localhost` | HugeGraphServer 的地址                                  |
+| `host`               | `localhost` | HugeGraphServer 的地址，可以是主机名或 IP，也可以带 `http://` / `https://` 前缀 |
 | `port`               | `8080`      | HugeGraphServer 的端口                                  |
 | `graph`              | `hugegraph` | 图名称                                                    |
 | `protocol`           | `http`      | 向服务器发送请求的协议，可选 `http` 或 `https`                       |
-| `username`           | `null`      | 当 HugeGraphServer 开启权限认证时，当前图的用户名                      |
+| `username`           | `null`      | 当 HugeGraphServer 开启权限认证时，当前图的用户名。未设置时使用图名称作为用户名        |
 | `token`              | `null`      | 当 HugeGraphServer 开启权限认证时，当前图的 token                   |
 | `timeout`            | `60`        | 插入结果返回的超时时间（秒）                                        |
 | `max-conn`           | `CPUS * 4`  | HugeClient 与 HugeGraphServer 之间的最大 HTTP 连接数            |
 | `max-conn-per-route` | `CPUS * 2`  | HugeClient 与 HugeGraphServer 之间每个路由的最大 HTTP 连接数         |
-| `trust-store-file`   | `null`      | 当请求协议为 https 时，客户端的证书文件路径                             |
-| `trust-store-token`  | `null`      | 当请求协议为 https 时，客户端的证书密码                               |
+| `trust-store-file`   | `null`      | 当请求协议为 https 时，客户端的证书文件路径。https 下未设置时，连接器会读取 JVM 系统属性 `connector.home.path` 指向目录下的 `conf/hugegraph.truststore`，此时该属性必须设置 |
+| `trust-store-token`  | `null`      | 当请求协议为 https 时，客户端的证书密码。https 下未设置时使用 `hugegraph`          |
 
 #### 5.2 图数据配置
 
@@ -164,14 +223,14 @@ df.write
 
 | 参数                | 默认值   | 说明                                                                                                                                                  |
 |-------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `data-type`       |       | 图数据类型，必须是 `vertex` 或 `edge`                                                                                                                        |
-| `label`           |       | 要导入的顶点/边数据所属的标签                                                                                                                                   |
-| `id`              |       | 指定某一列作为顶点的 id 列。当顶点 id 策略为 CUSTOMIZE 时，必填；当 id 策略为 PRIMARY_KEY 时，必须为空                                                                            |
-| `source-name`     |       | 选择输入源的某些列作为源顶点的 id 列。当源顶点的 id 策略为 CUSTOMIZE 时，必须指定某一列作为顶点的 id 列；当源顶点的 id 策略为 PRIMARY_KEY 时，必须指定一列或多列用于拼接生成顶点的 id，即无论使用哪种 id 策略，此项都是必填的        |
-| `target-name`     |       | 指定某些列作为目标顶点的 id 列，与 source-name 类似                                                                                                                 |
+| `data-type`       |       | 必填。图数据类型，必须是 `vertex` 或 `edge`                                                                                                                     |
+| `label`           |       | 必填。要导入的顶点/边数据所属的标签                                                                                                                                |
+| `id`              |       | 指定某一列作为顶点的 id 列。当顶点 id 策略为 CUSTOMIZE 时，必填；当 id 策略为 PRIMARY_KEY 时，必须为空。不支持 AUTOMATIC id 策略                                                          |
+| `source-name`     |       | 当 `data-type` 为 `edge` 时必填。选择输入源的某些列作为源顶点的 id 列。当源顶点的 id 策略为 CUSTOMIZE 时，必须指定某一列作为顶点的 id 列；当源顶点的 id 策略为 PRIMARY_KEY 时，必须指定一列或多列用于拼接生成顶点的 id，即无论使用哪种 id 策略，此项都是必填的。多列之间用 `,` 分隔（`delimiter` 选项对此项不生效） |
+| `target-name`     |       | 当 `data-type` 为 `edge` 时必填。指定某些列作为目标顶点的 id 列，与 source-name 类似                                                                                        |
 | `selected-fields` |       | 选择某些列进行插入，其他未选择的列不插入，不能与 ignored-fields 同时存在                                                                                                      |
 | `ignored-fields`  |       | 忽略某些列使其不参与插入，不能与 selected-fields 同时存在                                                                                                             |
-| `batch-size`      | `500` | 导入数据时每批数据的条目数                                                                                                                                      |
+| `batch-size`      | `500` | 导入数据时每批数据的条目数。按 Spark task 生效：每个分区的写入器在缓冲区累积到该数量的顶点/边时向服务端提交一次，commit 时再提交剩余部分                                                                    |
 
 #### 5.3 通用配置
 
@@ -179,8 +238,18 @@ df.write
 
 | 参数          | 默认值 | 说明                                                                 |
 |-------------|-----|-------------------------------------------------------------------|
-| `delimiter` | `,` | `source-name`、`target-name`、`selected-fields` 或 `ignored-fields` 的分隔符 |
+| `delimiter` | `,` | `selected-fields` 和 `ignored-fields` 的分隔符。`source-name` 和 `target-name` 始终按 `,` 拆分 |
 
-### 6 许可证
+### 6 注意事项与限制
+
+- 每个 Spark 写入 task 会创建自己的 HugeClient，写入前把图切换到 `LOADING` 模式，commit 或 abort 时恢复为 `NONE` 模式。
+- 顶点 id 长度限制为 128 字节（UTF-8），对自定义字符串 id 和由主键拼接出的 id 都生效。
+- 不支持 `AUTOMATIC` 顶点 id 策略，创建写入器时会抛出 `IllegalArgumentException`，写入失败。
+- 暂不支持 `SET` 或 `LIST` 基数的属性，只会转换 `SINGLE` 基数的值。
+- 日期属性：字符串值必须使用 `yyyy-MM-dd HH:mm:ss` 格式，按 `GMT+8` 时区解析；数值会被当作毫秒时间戳。
+- 以字符串形式给出的布尔属性接受 `true`、`1`、`yes`、`y` 和 `false`、`0`、`no`、`n`（不区分大小写）。
+- 自定义字符串 id 或任一主键值为空字符串的行会被跳过；为 null 时则会报错。
+
+### 7 许可证
 
 与 HugeGraph 一样，hugegraph-spark-connector 也采用 Apache 2.0 许可证。

--- a/content/en/docs/quickstart/toolchain/hugegraph-spark-connector.md
+++ b/content/en/docs/quickstart/toolchain/hugegraph-spark-connector.md
@@ -8,12 +8,14 @@ weight: 4
 
 HugeGraph-Spark-Connector uses the Spark DataFrame API to write bulk data to HugeGraph. The current implementation provides vertex and edge writers.
 
+Reading from HugeGraph is not implemented yet: the table only implements `SupportsWrite`, so `spark.read.format(...)` is not supported. The connector supports the `CUSTOMIZE` and `PRIMARY_KEY` vertex id strategies; the `AUTOMATIC` strategy is rejected.
+
 ### 2 Environment Requirements
 
 - Java 8+
 - Maven 3.6+
-- Spark 3.x
-- Scala 2.12
+- Spark 3.2.x (the module is built against Spark 3.2.2 with `provided` scope, so your Spark runtime must supply the Spark jars)
+- Scala 2.12 (built with Scala 2.12.11)
 
 ### 3 Building
 
@@ -31,6 +33,8 @@ mvn clean package -pl hugegraph-spark-connector -am -DskipTests -ntp
 mvn clean package -pl hugegraph-spark-connector -am -ntp
 ```
 
+Both commands produce a fat jar at `hugegraph-spark-connector/target/hugegraph-spark-connector-${revision}-jar-with-dependencies.jar` (Spark itself is not bundled). Pass it to `spark-submit --jars` when you do not manage the dependency through Maven.
+
 ### 4 Usage
 
 Add the dependency to `pom.xml`, replacing `${revision}` with the release version you use:
@@ -42,6 +46,8 @@ Add the dependency to `pom.xml`, replacing `${revision}` with the release versio
     <version>${revision}</version>
 </dependency>
 ```
+
+The `format` string must be the full class name `org.apache.hugegraph.spark.connector.DataSource`; the connector does not register a short name with Spark's `DataSourceRegister` service loader. When HugeGraphServer has authentication enabled, add `.option("username", ...)` and `.option("token", ...)` to the examples below.
 
 #### 4.1 Schema Definition Example
 
@@ -136,7 +142,60 @@ df.write
   .save()
 ```
 
+#### 4.4 Vertex Sink with PRIMARY_KEY id strategy (Scala)
+
+For a vertex label that uses `primaryKeys(...)`, do not set the `id` option: the id is spliced from the primary key columns. Columns that are not part of the schema can be dropped with `ignored-fields`.
+
+```scala
+val df = sparkSession.createDataFrame(Seq(
+  Tuple4("lop", "java", 328L, "ISBN978-7-107-18618-5"),
+  Tuple4("ripple", "python", 199L, "ISBN978-7-100-13678-5"),
+)).toDF("name", "lang", "price", "ISBN")
+
+df.write
+  .format("org.apache.hugegraph.spark.connector.DataSource")
+  .option("host", "127.0.0.1")
+  .option("port", "8080")
+  .option("graph", "hugegraph")
+  .option("data-type", "vertex")
+  .option("label", "software")
+  .option("ignored-fields", "ISBN")
+  .option("batch-size", 2)
+  .mode(SaveMode.Overwrite)
+  .save()
+```
+
+#### 4.5 Edge Sink with mixed id strategies (Scala)
+
+`source-name` and `target-name` follow the id strategy of their own vertex label. Below, `person` uses a customized string id (one column) while `software` uses a primary key (its `name` column):
+
+```scala
+val df = sparkSession.createDataFrame(Seq(
+  Tuple4("marko", "lop", "20171210", 0.5),
+  Tuple4("Josh", "lop", "20091111", 0.4),
+  Tuple4("peter", "ripple", "20171210", 1.0),
+  Tuple4("vadas", "lop", "20171210", 0.2)
+)).toDF("source", "name", "date", "weight")
+
+df.write
+  .format("org.apache.hugegraph.spark.connector.DataSource")
+  .option("host", "127.0.0.1")
+  .option("port", "8080")
+  .option("graph", "hugegraph")
+  .option("data-type", "edge")
+  .option("label", "created")
+  .option("source-name", "source") // customize id
+  .option("target-name", "name")   // primary key
+  .option("batch-size", 2)
+  .mode(SaveMode.Overwrite)
+  .save()
+```
+
+Note on save modes: `SaveMode.Overwrite` and `SaveMode.Append` both insert the rows. The overwrite path does not delete existing data from the graph first.
+
 ### 5 Configuration Parameters
+
+Option keys are matched case-insensitively and trimmed. `data-type` and `label` are always required; `source-name` and `target-name` are required when `data-type` is `edge`; all other options have defaults.
 
 #### 5.1 Client Configs
 
@@ -144,17 +203,17 @@ Client Configs are used to configure hugegraph-client.
 
 | Parameter            | Default Value | Description                                                                                  |
 |----------------------|---------------|----------------------------------------------------------------------------------------------|
-| `host`               | `localhost`   | Address of HugeGraphServer                                                                   |
+| `host`               | `localhost`   | Address of HugeGraphServer. A bare host name or IP, or a full `http://` / `https://` prefix   |
 | `port`               | `8080`        | Port of HugeGraphServer                                                                      |
 | `graph`              | `hugegraph`   | Graph name                                                                                   |
 | `protocol`           | `http`        | Protocol for sending requests to the server, optional `http` or `https`                      |
-| `username`           | `null`        | Username of the current graph when HugeGraphServer enables permission authentication         |
+| `username`           | `null`        | Username of the current graph when HugeGraphServer enables permission authentication. When unset, the graph name is used as the username |
 | `token`              | `null`        | Token of the current graph when HugeGraphServer has enabled authorization authentication     |
 | `timeout`            | `60`          | Timeout (seconds) for inserting results to return                                            |
 | `max-conn`           | `CPUS * 4`    | The maximum number of HTTP connections between HugeClient and HugeGraphServer                |
 | `max-conn-per-route` | `CPUS * 2`    | The maximum number of HTTP connections for each route between HugeClient and HugeGraphServer |
-| `trust-store-file`   | `null`        | The client's certificate file path when the request protocol is https                        |
-| `trust-store-token`  | `null`        | The client's certificate password when the request protocol is https                         |
+| `trust-store-file`   | `null`        | The client's certificate file path when the request protocol is https. When unset under https, the connector reads `conf/hugegraph.truststore` under the directory given by the JVM system property `connector.home.path`, which must then be set |
+| `trust-store-token`  | `null`        | The client's certificate password when the request protocol is https. When unset under https, `hugegraph` is used                         |
 
 #### 5.2 Graph Data Configs
 
@@ -162,14 +221,14 @@ Graph Data Configs describe how DataFrame columns map to vertices or edges.
 
 | Parameter         | Default Value | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
 |-------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `data-type`       |               | Graph data type, must be `vertex` or `edge`                                                                                                                                                                                                                                                                                                                                                                                |
-| `label`           |               | Label to which the vertex/edge data to be imported belongs                                                                                                                                                                                                                                                                                                                                                                 |
-| `id`              |               | Specify a column as the id column of the vertex. When the vertex id policy is CUSTOMIZE, it is required; when the id policy is PRIMARY_KEY, it must be empty                                                                                                                                                                                                                                                               |
-| `source-name`     |               | Select certain columns of the input source as the id column of source vertex. When the id policy of the source vertex is CUSTOMIZE, a certain column must be specified as the id column of the vertex; when the id policy of the source vertex is PRIMARY_KEY, one or more columns must be specified for splicing the id of the generated vertex, that is, no matter which id strategy is used, this item is required |
-| `target-name`     |               | Specify certain columns as the id columns of target vertex, similar to source-name                                                                                                                                                                                                                                                                                                                                         |
+| `data-type`       |               | Required. Graph data type, must be `vertex` or `edge`                                                                                                                                                                                                                                                                                                                                                                      |
+| `label`           |               | Required. Label to which the vertex/edge data to be imported belongs                                                                                                                                                                                                                                                                                                                                                       |
+| `id`              |               | Specify a column as the id column of the vertex. When the vertex id policy is CUSTOMIZE, it is required; when the id policy is PRIMARY_KEY, it must be empty. The AUTOMATIC id policy is not supported                                                                                                                                                                                                                       |
+| `source-name`     |               | Required when `data-type` is `edge`. Select certain columns of the input source as the id column of source vertex. When the id policy of the source vertex is CUSTOMIZE, a certain column must be specified as the id column of the vertex; when the id policy of the source vertex is PRIMARY_KEY, one or more columns must be specified for splicing the id of the generated vertex, that is, no matter which id strategy is used, this item is required. Multiple columns are separated by `,` (the `delimiter` option does not apply here) |
+| `target-name`     |               | Required when `data-type` is `edge`. Specify certain columns as the id columns of target vertex, similar to source-name                                                                                                                                                                                                                                                                                                    |
 | `selected-fields` |               | Select some columns to insert, other unselected ones are not inserted, cannot exist at the same time as ignored-fields                                                                                                                                                                                                                                                                                                     |
 | `ignored-fields`  |               | Ignore some columns so that they do not participate in insertion, cannot exist at the same time as selected-fields                                                                                                                                                                                                                                                                                                         |
-| `batch-size`      | `500`         | The number of data items in each batch when importing data                                                                                                                                                                                                                                                                                                                                                                 |
+| `batch-size`      | `500`         | The number of data items in each batch when importing data. Applied per Spark task: each partition writer flushes its buffer to the server once it holds this many vertices/edges, and again at commit for the remainder                                                                                                                                                                                                   |
 
 #### 5.3 Common Configs
 
@@ -177,8 +236,18 @@ Common Configs contains some common configurations.
 
 | Parameter   | Default Value | Description                                                                     |
 |-------------|---------------|---------------------------------------------------------------------------------|
-| `delimiter` | `,`           | Separator of `source-name`, `target-name`, `selected-fields` or `ignored-fields` |
+| `delimiter` | `,`           | Separator of `selected-fields` and `ignored-fields`. `source-name` and `target-name` are always split on `,` |
 
-### 6 License
+### 6 Notes and Limitations
+
+- Each Spark write task opens its own HugeClient, switches the graph to `LOADING` mode before writing and sets it back to `NONE` at commit or abort.
+- Vertex ids are limited to 128 bytes (UTF-8). This applies to customized string ids and to ids spliced from primary keys.
+- The `AUTOMATIC` vertex id strategy is not supported; the write fails with an `IllegalArgumentException` when the writer is created.
+- Properties with `SET` or `LIST` cardinality are not supported yet; only `SINGLE` cardinality values are converted.
+- Date properties: string values must use the format `yyyy-MM-dd HH:mm:ss` and are parsed in the `GMT+8` time zone; numeric values are treated as epoch milliseconds.
+- Boolean properties given as strings accept `true`, `1`, `yes`, `y` and `false`, `0`, `no`, `n` (case-insensitive).
+- Rows whose customized string id, or any primary key value, is an empty string are skipped. A null id or primary key value raises an error instead.
+
+### 7 License
 
 The same as HugeGraph, hugegraph-spark-connector is also licensed under Apache 2.0 License.


### PR DESCRIPTION
## Purpose of the PR

Sync the hugegraph-spark-connector docs (en + cn) with hugegraph-toolchain master (3b385c3d).

Every row below applies to both `content/en/docs/quickstart/toolchain/hugegraph-spark-connector.md` and `content/cn/docs/quickstart/toolchain/hugegraph-spark-connector.md`; the two pages are kept in sync.

| Page | What was wrong | What changed | Source on master |
|------|----------------|--------------|------------------|
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | Overview did not say that reading is unsupported or which id strategies work | Added a note: the table only implements `SupportsWrite`; `CUSTOMIZE` and `PRIMARY_KEY` supported, `AUTOMATIC` rejected | hugegraph-spark-connector/src/main/scala/org/apache/hugegraph/spark/connector/HGTable.scala:30, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/builder/VertexBuilder.java:79 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | Environment listed a vague "Spark 3.x" and "Scala 2.12" | Pinned to Spark 3.2.2 (`provided` scope) and Scala 2.12.11 | hugegraph-spark-connector/pom.xml:43, hugegraph-spark-connector/pom.xml:44, hugegraph-spark-connector/pom.xml:48 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | Build section never said what artifact the build produces | Documented the `*-jar-with-dependencies.jar` output for `spark-submit --jars` | hugegraph-spark-connector/pom.xml:207, hugegraph-spark-connector/pom.xml:210 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | Usage did not state that `format` must be the full class name, nor how to pass auth | Added a sentence on the full class name (no `DataSourceRegister` service file under `src/main/resources`) and on `username` / `token` options | hugegraph-spark-connector/src/test/scala/org/apache/hugegraph/spark/connector/SinkExampleTest.scala:59, hugegraph-spark-connector/src/test/scala/org/apache/hugegraph/spark/connector/SinkExampleTest.scala:82 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | No example for a PRIMARY_KEY vertex label or for `ignored-fields` | Added section 4.4 (software vertex, no `id`, `ignored-fields=ISBN`) | hugegraph-spark-connector/src/test/scala/org/apache/hugegraph/spark/connector/SinkExampleTest.scala:96 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | No example of an edge whose source and target use different id strategies | Added section 4.5 (created edge, customize source + primary key target) | hugegraph-spark-connector/src/test/scala/org/apache/hugegraph/spark/connector/SinkExampleTest.scala:157 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | Nothing said what `SaveMode.Overwrite` does | Added a note: overwrite returns a plain writer and does not delete existing data | hugegraph-spark-connector/src/main/scala/org/apache/hugegraph/spark/connector/writer/HGWriterBuilder.scala:35 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | Required options and key matching rules were not stated | Added an intro to section 5: keys lowercased and trimmed; `data-type`, `label` required; `source-name`, `target-name` required for edges; marked those rows "Required" | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:73, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:84, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:89, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:93, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:97 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | `host` row did not mention that a scheme prefix is accepted | Noted that `host` may carry an `http://` or `https://` prefix | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/client/HGClientHolder.java:47 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | `username` row omitted the fallback | Noted that the graph name is used when `username` is unset | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/client/HGClientHolder.java:54 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | `trust-store-file` and `trust-store-token` rows omitted the https fallbacks | Documented `${connector.home.path}/conf/hugegraph.truststore` (system property required) and the `hugegraph` default password | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/client/HGClientHolder.java:65, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/client/HGClientHolder.java:72, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/constant/Constants.java:32, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/constant/Constants.java:52 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | `id` row did not say AUTOMATIC is unsupported | Added that the AUTOMATIC id policy is not supported | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/builder/VertexBuilder.java:79 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | `batch-size` row did not say the batch is per Spark task | Explained per-partition buffering and the flush at commit | hugegraph-spark-connector/src/main/scala/org/apache/hugegraph/spark/connector/writer/HGVertexWriter.scala:56, hugegraph-spark-connector/src/main/scala/org/apache/hugegraph/spark/connector/writer/HGEdgeWriter.scala:56 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | `delimiter` row claimed it also splits `source-name` and `target-name`; the code always splits those on `,` | Limited `delimiter` to `selected-fields` and `ignored-fields`; noted `,` for source/target | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:228, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:240, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:248, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/options/HGOptions.java:260 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-spark-connector.md | No notes on runtime behaviour and limits | Added section 6 "Notes and Limitations": per-task HugeClient and LOADING mode, 128 byte vertex id limit, SET/LIST cardinality unsupported, date format `yyyy-MM-dd HH:mm:ss` in GMT+8, accepted boolean strings, empty vs null id handling; License moved to section 7 | hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/client/HGLoadContext.java:66, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/client/HGLoadContext.java:81, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/builder/ElementBuilder.java:211, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/utils/DataTypeUtils.java:54, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/constant/Constants.java:48, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/constant/Constants.java:50, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/utils/DataTypeUtils.java:35, hugegraph-spark-connector/src/main/java/org/apache/hugegraph/spark/connector/utils/DataTypeUtils.java:39 |
