### PR TITLE
doc(toolchain): sync tools with master

### DIFF
--- a/content/cn/docs/guides/backup-restore.md
+++ b/content/cn/docs/guides/backup-restore.md
@@ -34,20 +34,20 @@ Restore 有两种模式：
 bin/hugegraph backup -t all -d data
 ```
 
-该命令将 http://127.0.0.1 的 hugegraph 图的全部元数据和图数据备份到data目录下。
+该命令将 http://127.0.0.1:8080（默认 --url）的 hugegraph 图的全部元数据和图数据备份到data目录下。
 
-> Backup 在三种图模式下都可以正常工作
+> Backup 在任意图模式下都可以正常工作，它不会检查图模式
 
 #### Restore
 
-Restore 有两种模式： RESTORING 和 MERGING，备份之前首先要根据需要设置图模式。
+Restore 有两种模式： RESTORING 和 MERGING，恢复之前首先要根据需要设置图模式，图处于其他模式时 restore 命令会失败。
 
 ##### 步骤1：查看并设置图模式
 
 ```bash
 bin/hugegraph graph-mode-get
 ```
-该命令用于查看当前图模式，包括：NONE、RESTORING、MERGING。
+该命令用于查看当前图模式，包括：NONE、RESTORING、MERGING、LOADING。
 
 ```bash
 bin/hugegraph graph-mode-set -m RESTORING
@@ -59,7 +59,7 @@ bin/hugegraph graph-mode-set -m RESTORING
 ```bash
 bin/hugegraph restore -t all -d data
 ```
-该命令将data目录下的全部元数据和图数据重新导入到 http://127.0.0.1 的 hugegraph 图中。
+该命令将data目录下的全部元数据和图数据重新导入到 http://127.0.0.1:8080 的 hugegraph 图中。
 
 ##### 步骤3：恢复图模式
 

--- a/content/cn/docs/quickstart/toolchain/hugegraph-tools.md
+++ b/content/cn/docs/quickstart/toolchain/hugegraph-tools.md
@@ -26,6 +26,9 @@ export VERSION=1.7.0
 export ARCHIVE="apache-hugegraph-toolchain-incubating-${VERSION}"
 wget "https://downloads.apache.org/hugegraph/${VERSION}/${ARCHIVE}.tar.gz"
 tar zxf "${ARCHIVE}.tar.gz"
+# hugegraph-tools 位于 toolchain 发布包的子目录中，
+# 其版本后缀与发布包本身一致
+cd "${ARCHIVE}/apache-hugegraph-tools-incubating-${VERSION}"
 ```
 
 #### 2.2 下载源码编译安装
@@ -50,14 +53,14 @@ cd hugegraph-toolchain
 mvn package -pl hugegraph-tools -am -DskipTests -ntp
 ```
 
-生成 tar 包 hugegraph-tools-${version}.tar.gz
+生成的 tar 包位于 `hugegraph-tools/target/apache-hugegraph-tools-${version}.tar.gz`，同时会在 `hugegraph-tools/apache-hugegraph-tools-${version}` 生成解压后的目录（包含 `bin/` 和 `lib/`）
 
 
 ### 3 使用
 
 #### 3.1 功能概览
 
-解压后，进入 hugegraph-tools 目录，可以使用`bin/hugegraph`或者`bin/hugegraph help`来查看 usage 信息。主要分为：
+解压后，进入 apache-hugegraph-tools-${version} 目录，可以使用`bin/hugegraph`或者`bin/hugegraph help`来查看 usage 信息，使用`bin/hugegraph help <子命令>`查看单个子命令的 usage。主要分为：
 
 - 图管理类，graph-mode-set、graph-mode-get、graph-list、graph-get、graph-clear、graph-create、graph-clone 和 graph-drop
 - 异步任务管理类，task-list、task-get、task-delete、task-cancel 和 task-clear
@@ -79,9 +82,11 @@ Usage: hugegraph [options] [command] [command options]
 - --user，当 HugeGraph-Server 开启认证时，传递用户名
 - --password，当 HugeGraph-Server 开启认证时，传递用户的密码
 - --timeout，连接 HugeGraph-Server 时的超时时间，默认是 30s
-- --protocol，连接协议，可选 http 或 https，默认是 http
 - --trust-store-file，证书文件的路径，当 --url 使用 https 时，HugeGraph-Client 使用的 truststore 文件，默认为空，代表使用 hugegraph-tools 内置的 truststore 文件 conf/hugegraph.truststore
 - --trust-store-password，证书文件的密码，当 --url 使用 https 时，HugeGraph-Client 使用的 truststore 的密码，默认为空，代表使用 hugegraph-tools 内置的 truststore 文件的密码
+- --throw-mode，HugeGraph-Tools 出错时是否直接抛出异常，而不是打印错误信息后退出，默认为 false（主要用于测试）
+
+> 连接协议由 --url 的 scheme 决定：使用 `https://...` 即通过 https 连接。--trust-store-file 和 --trust-store-password 只能在 --url 使用 https 时设置，--user 和 --password 必须同时提供或同时省略。
 
 上述全局变量，也可以通过环境变量来设置。一种方式是在命令行使用 export 设置临时环境变量，在该命令行关闭之前均有效
 
@@ -111,6 +116,8 @@ Usage: hugegraph [options] [command] [command options]
 #export HUGEGRAPH_TRUST_STORE_PASSWORD=
 ```
 
+`bin/hugegraph` 还会读取 `JAVA_HOME`（未设置时打印警告，https 需要它）和 `JAVA_OPTIONS`（JVM 参数，为空时脚本使用 `-Xms512m`，并根据机器空闲内存计算 `-Xmx`）。
+
 ##### 3.3 图管理类，graph-mode-set、graph-mode-get、graph-list、graph-get、graph-clear、graph-create、graph-clone和graph-drop
 
 - graph-mode-set，设置图的 restore mode
@@ -121,27 +128,29 @@ Usage: hugegraph [options] [command] [command options]
 - graph-clear，清除某个图的全部 schema 和 data
     - --confirm-message 或者 -c，必填项，删除确认信息，需要手动输入，二次确认防止误删，"I'm sure to delete all data"，包括双引号
 - graph-create，使用配置文件创建新图
-    - --name 或者 -n，选填项，新图的名称，默认为 hugegraph
-    - --file 或者 -f，必填项，图配置文件的路径
+    - --name 或者 -n，选填项，新图的名称，默认为 g
+    - --file 或者 -f，图配置文件的路径，文件内容会作为新图的配置发送给 HugeGraph-Server
 - graph-clone，克隆已存在的图
-    - --name 或者 -n，选填项，新克隆图的名称，默认为 hugegraph
+    - --name 或者 -n，选填项，新克隆图的名称，默认为 g
     - --clone-graph-name，选填项，要克隆的源图名称，默认为 hugegraph
 - graph-drop，删除图（不同于 graph-clear，这会完全删除图）
     - --confirm-message 或者 -c，必填项，确认消息 "I'm sure to drop the graph"，包括双引号
 
+> graph-create、graph-clone、graph-clear 和 graph-drop 会将 --timeout 提升到至少 300 秒。
+
 > 当需要把备份的图原样恢复到一个新的图中的时候，需要先将图模式设置为 RESTORING 模式；当需要将备份的图合并到已存在的图中时，需要先将图模式设置为 MERGING 模式。
 
-##### 3.4 异步任务管理类，task-list、task-get和task-delete
+##### 3.4 异步任务管理类，task-list、task-get、task-delete、task-cancel 和 task-clear
 
 - task-list，列出某个图中的异步任务，可以根据任务的状态过滤
-    - --status，选填项，指定要查看的任务的状态，即按状态过滤任务
-    - --limit，选填项，指定要获取的任务的数目，默认为 -1，意思为获取全部符合条件的任务
+    - --status，选填项，指定要查看的任务的状态，即按状态过滤任务，合法值包括 [UNKNOWN, NEW, QUEUED, RESTORING, RUNNING, SUCCESS, CANCELLED, FAILED]（不区分大小写）
+    - --limit，选填项，指定要获取的任务的数目，默认为 -1，意思为获取全部符合条件的任务，显式传入的值必须为正数
 - task-get，获取某个异步任务的详细信息
     - --task-id，必填项，指定异步任务的 ID
 - task-delete，删除某个异步任务的信息
     - --task-id，必填项，指定异步任务的 ID
 - task-cancel，取消某个异步任务的执行
-    - --task-id，要取消的异步任务的 ID
+    - --task-id，必填项，要取消的异步任务的 ID
 - task-clear，清理完成的异步任务
     - --force，选填项，设置时，表示清理全部异步任务，未执行完成的先取消，然后清除所有异步任务。默认只清理已完成的异步任务
 
@@ -166,25 +175,27 @@ Usage: hugegraph [options] [command] [command options]
 - backup，将某张图中的 schema 或者 data 备份到 HugeGraph 系统之外，以 JSON 形式存在本地磁盘或者 HDFS
     - --format，备份的格式，可选值包括 [json, text]，默认为 json
     - --all-properties，是否备份顶点/边全部的属性，仅在 --format 为 text 是有效，默认 false
-    - --label，要备份的顶点/边的类型，仅在 --format 为 text 是有效，只有备份顶点或者边的时候有效
+    - --label，要备份的顶点 label 或者边 label，仅在 --format 为 text 时生效；设置该项时，--huge-types 必须只包含一种类型，且该类型必须是 vertex 或者 edge，否则命令会失败
     - --properties，要备份的顶点/边的属性，逗号分隔，仅在 --format 为 text 是有效，只有备份顶点或者边的时候有效
     - --compress，备份时是否压缩数据，默认为 true
     - --directory 或者 -d，存储 schema 或者 data 的目录，本地目录时，默认为'./{graphName}'，HDFS 时，默认为 '{fs.default.name}/{graphName}'
-    - --huge-types 或者 -t，要备份的数据类型，逗号分隔，可选值为 'all' 或者 一个或多个 [vertex,edge,vertex_label,edge_label,property_key,index_label] 的组合，'all' 代表全部6种类型，即顶点、边和所有schema
-    - --log 或者 -l，指定日志目录，默认为当前目录
+    - --huge-types 或者 -t，要备份的数据类型，逗号分隔，可选值为 'all' 或者 一个或多个 [vertex,edge,vertex_label,edge_label,property_key,index_label] 的组合，'all' 代表全部6种类型，即顶点、边和所有schema，'schema' 代表 4 种 schema 类型 [vertex_label, edge_label, property_key, index_label]
+    - --log 或者 -l，指定日志目录，默认为 ./logs
     - --retry，指定失败重试次数，默认为 3
     - --thread-num 或者 -T，使用的线程数，默认为 Math.min(10, Math.max(4, CPUs / 2))
-    - --split-size 或者 -s，指定在备份时对顶点或者边分块的大小，默认为 1048576
-    - -D，用 -Dkey=value 的模式指定动态参数，用来备份数据到 HDFS 时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000 
+    - --split-size 或者 -s，指定在备份时对顶点或者边分块的大小，默认为 1048576，且不能小于 1048576（1M）
+    - -D，用 -Dkey=value 的模式指定动态参数，用来备份数据到 HDFS 时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000
+    > 当 --timeout 小于 120 秒时，backup（以及 migrate 中的备份步骤）会使用 120 秒
 - restore，将 JSON 格式存储的 schema 或者 data 恢复到一个新图中（RESTORING 模式）或者合并到已存在的图中（MERGING 模式）
     - --directory 或者 -d，存储 schema 或者 data 的目录，本地目录时，默认为'./{graphName}'，HDFS 时，默认为 '{fs.default.name}/{graphName}'
     - --clean，是否在恢复图完成后删除 --directory 指定的目录，默认为 false
-    - --huge-types 或者 -t，要恢复的数据类型，逗号分隔，可选值为 'all' 或者 一个或多个 [vertex,edge,vertex_label,edge_label,property_key,index_label] 的组合，'all' 代表全部6种类型，即顶点、边和所有schema
-    - --log 或者 -l，指定日志目录，默认为当前目录
+    - --huge-types 或者 -t，要恢复的数据类型，逗号分隔，可选值为 'all' 或者 一个或多个 [vertex,edge,vertex_label,edge_label,property_key,index_label] 的组合，'all' 代表全部6种类型，即顶点、边和所有schema，'schema' 代表 4 种 schema 类型 [vertex_label, edge_label, property_key, index_label]
+    - --log 或者 -l，指定日志目录，默认为 ./logs
     - --retry，指定失败重试次数，默认为 3
     - --thread-num 或者 -T，使用的线程数，默认为 Math.min(10, Math.max(4, CPUs / 2))
     - -D，用 -Dkey=value 的模式指定动态参数，用来从 HDFS 恢复图时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000
     > 只有当 --format 为 json 执行 backup 时，才可以使用 restore 命令恢复
+    > restore 要求图处于 RESTORING 或 MERGING 模式（先用 graph-mode-set 设置），否则命令会失败
 - migrate，将当前连接的图迁移至另一个 HugeGraphServer 中
     - --target-graph，目标图的名字，默认为 hugegraph
     - --target-url，目标图所在的 HugeGraphServer，默认为 http://127.0.0.1:8081
@@ -194,60 +205,61 @@ Usage: hugegraph [options] [command] [command options]
     - --target-trust-store-file，访问目标图使用的 truststore 文件
     - --target-trust-store-password，访问目标图使用的 truststore 的密码
     - --directory 或者 -d，迁移过程中，存储源图的 schema 或者 data 的目录，本地目录时，默认为'./{graphName}'，HDFS 时，默认为 '{fs.default.name}/{graphName}'
-    - --huge-types 或者 -t，要迁移的数据类型，逗号分隔，可选值为 'all' 或者 一个或多个 [vertex,edge,vertex_label,edge_label,property_key,index_label] 的组合，'all' 代表全部6种类型，即顶点、边和所有schema
-    - --log 或者 -l，指定日志目录，默认为当前目录
+    - --huge-types 或者 -t，要迁移的数据类型，逗号分隔，可选值为 'all' 或者 一个或多个 [vertex,edge,vertex_label,edge_label,property_key,index_label] 的组合，'all' 代表全部6种类型，即顶点、边和所有schema，'schema' 代表 4 种 schema 类型 [vertex_label, edge_label, property_key, index_label]
+    - --log 或者 -l，指定日志目录，默认为 ./logs
     - --retry，指定失败重试次数，默认为 3
-    - --split-size 或者 -s，指定迁移过程中对源图进行备份时顶点或者边分块的大小，默认为 1048576
+    - --thread-num 或者 -T，使用的线程数，默认为 Math.min(10, Math.max(4, CPUs / 2))
+    - --split-size 或者 -s，指定迁移过程中对源图进行备份时顶点或者边分块的大小，默认为 1048576，且不能小于 1048576（1M）
     - -D，用 -Dkey=value 的模式指定动态参数，用来在迁移图过程中需要备份数据到 HDFS 时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000
-    - --graph-mode 或者 -m，将源图恢复到目标图时将目标图设置的模式，合法值包括 [RESTORING, MERGING]
+    - --graph-mode 或者 -m，将源图恢复到目标图时将目标图设置的模式，合法值包括 [RESTORING, MERGING]，默认为 RESTORING。迁移期间目标图会被切换到该模式，迁移结束后恢复为原来的模式
     - --keep-local-data，是否保留在迁移图的过程中产生的源图的备份，默认为 false，即默认迁移图结束后不保留产生的源图备份
 - schedule-backup，周期性对图执行备份操作，并保留一定数目的最新备份（目前仅支持本地文件系统）
     - --directory 或者 -d，必填项，指定备份数据的目录
     - --backup-num，选填项，指定保存的最新的备份的数目，默认为 3
-    - --interval，选填项，指定进行备份的周期，格式同 Linux crontab 格式
+    - --interval，选填项，指定进行备份的周期，格式同 Linux crontab 格式，默认为 "0 0 * * *"（每天 00:00）
+    > schedule-backup 会添加一条 crontab 任务，定期执行 `backup -t all` 并写入 `{directory}/{graph}/hugegraph-backup-{yyMMddHHmm}/`，只保留最新的 --backup-num 份备份。相对路径的 --directory 会相对于 hugegraph-tools 的根目录解析，且 `{directory}/{graph}` 必须尚不存在
 - dump，把整张图的顶点和边全部导出，默认以 `vertex vertex-edge1 vertex-edge2...` 的 JSON 格式存储。
 用户也可以自定义存储格式。在 `hugegraph-tools/src/main/java/org/apache/hugegraph/formatter` 下实现一个继承自 `Formatter` 的类，例如 `CustomFormatter`，使用时指定该类为 formatter：
 `bin/hugegraph dump -f CustomFormatter`
     - --formatter 或者 -f，指定使用的 formatter，默认为 JsonFormatter
-    - --directory 或者 -d，存储 schema 或者 data 的目录，默认为当前目录
-    - --log 或者 -l，指定日志目录，默认为当前目录
+    - --directory 或者 -d，存储 schema 或者 data 的目录，本地目录时，默认为'./{graphName}'，HDFS 时，默认为 '{fs.default.name}/{graphName}'
+    - --log 或者 -l，指定日志目录，默认为 ./logs
     - --retry，指定失败重试次数，默认为 3
-    - --split-size 或者 -s，指定在备份时对顶点或者边分块的大小，默认为 1048576
+    - --thread-num 或者 -T，使用的线程数，默认为 Math.min(10, Math.max(4, CPUs / 2))
+    - --split-size 或者 -s，指定在备份时对顶点或者边分块的大小，默认为 1048576，且不能小于 1048576（1M）
     - -D，用 -Dkey=value 的模式指定动态参数，用来备份数据到 HDFS 时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000
 
 ##### 3.7 认证数据备份/恢复类
 
 - auth-backup，备份认证数据到指定目录
-    - --types 或者 -t，要备份的认证数据类型，逗号分隔，可选值为 'all' 或者一个或多个 [user, group, target, belong, access] 的组合，'all' 代表全部5种类型
-    - --directory 或者 -d，备份数据存储目录，默认为当前目录
-    - --log 或者 -l，指定日志目录，默认为当前目录
+    - --types 或者 -t，要备份的认证数据类型，逗号分隔，可选值为 'all' 或者一个或多个 [user, group, target, belong, access] 的组合，'all' 代表全部5种类型；包含 'belong' 时必须同时包含 'user' 和 'group'，包含 'access' 时必须同时包含 'group' 和 'target'
+    - --directory，备份数据存储目录，本地目录时，默认为 './auth-backup-restore'，HDFS 时，默认为 '{fs.default.name}/auth-backup-restore'（该选项没有 -d 短写）
     - --retry，指定失败重试次数，默认为 3
-    - --thread-num 或者 -T，使用的线程数，默认为 Math.min(10, Math.max(4, CPUs / 2))
     - -D，用 -Dkey=value 的模式指定动态参数，用来备份数据到 HDFS 时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000
 - auth-restore，从指定目录恢复认证数据
-    - --types 或者 -t，要恢复的认证数据类型，逗号分隔，可选值为 'all' 或者一个或多个 [user, group, target, belong, access] 的组合，'all' 代表全部5种类型
-    - --directory 或者 -d，备份数据存储目录，默认为当前目录
-    - --log 或者 -l，指定日志目录，默认为当前目录
+    - --types 或者 -t，要恢复的认证数据类型，逗号分隔，可选值为 'all' 或者一个或多个 [user, group, target, belong, access] 的组合，'all' 代表全部5种类型；包含 'belong' 时必须同时包含 'user' 和 'group'，包含 'access' 时必须同时包含 'group' 和 'target'
+    - --directory，备份数据存储目录，本地目录时，默认为 './auth-backup-restore'，HDFS 时，默认为 '{fs.default.name}/auth-backup-restore'（该选项没有 -d 短写）
     - --retry，指定失败重试次数，默认为 3
-    - --thread-num 或者 -T，使用的线程数，默认为 Math.min(10, Math.max(4, CPUs / 2))
     - --strategy，冲突处理策略，可选值为 [stop, ignore]，默认为 stop。stop 表示遇到冲突时停止恢复，ignore 表示忽略冲突继续恢复
-    - --init-password，恢复用户时设置的初始密码，恢复用户数据时必填
+    - --init-password，恢复用户时设置的初始密码，当 --types 包含 user 时必填
     - -D，用 -Dkey=value 的模式指定动态参数，用来从 HDFS 恢复数据时，指定 HDFS 的配置项，例如：-Dfs.default.name=hdfs://localhost:9000
 
 ##### 3.8 安装部署类
 
 - deploy，一键下载、安装和启动 HugeGraph-Server 和 HugeGraph-Studio
-    - -v，必填项，指定要安装的 HugeGraph-Server 和 HugeGraph-Studio 版本
+    - -v，必填项，指定要安装的 HugeGraph-Server 和 HugeGraph-Studio 版本，必须是 bin/version-map.yaml 中列出的版本之一（0.6、0.7、0.8、0.9、0.10），脚本据此映射到对应的 server 和 studio 发布版本
     - -p，必填项，指定安装的 HugeGraph-Server 和 HugeGraph-Studio 目录
     - -u，选填项，指定下载 HugeGraph-Server 和 HugeGraph-Studio 压缩包的链接
-- clear，清理 HugeGraph-Server 和 HugeGraph-Studio 目录和tar包
+- clear，清理 HugeGraph-Server 和 HugeGraph-Studio 目录和tar包（若对应的 server 或 studio 进程仍在运行则拒绝执行，删除每一项前都会提示确认）
     - -p，必填项，指定要清理的 HugeGraph-Server 和 HugeGraph-Studio 的目录
-- start-all，一键启动 HugeGraph-Server 和 HugeGraph-Studio，并启动监控，服务死掉时自动拉起服务
-    - -v，必填项，指定已安装的 HugeGraph-Server 和 HugeGraph-Studio 版本
+- start-all，一键启动 HugeGraph-Server 和 HugeGraph-Studio
+    - -v，必填项，指定已安装的 HugeGraph-Server 和 HugeGraph-Studio 版本，取值同 deploy
     - -p，必填项，指定安装了 HugeGraph-Server 和 HugeGraph-Studio 的目录
 - stop-all，一键关闭 HugeGraph-Server 和 HugeGraph-Studio
 
-> deploy命令中有可选参数 -u，提供时会使用指定的下载地址替代默认下载地址下载 tar 包，并且将地址写入`~/hugegraph-download-url-prefix`文件中；之后如果不指定地址时，会优先从`~/hugegraph-download-url-prefix`指定的地址下载 tar 包；如果 -u 和`~/hugegraph-download-url-prefix`都没有时，会从默认下载地址进行下载
+> deploy、start-all、clear 和 stop-all 由 `bin/hugegraph` 直接转交给 `bin/deploy.sh`、`bin/start-all.sh`、`bin/clear.sh` 和 `bin/stop-all.sh` 执行，因此 3.2 中的全局变量和环境变量对它们不生效。
+
+> deploy命令中有可选参数 -u，提供时会使用指定的下载地址替代默认下载地址下载 tar 包，并且将地址写入`~/hugegraph-download-url-prefix`文件中；之后如果不指定地址时，会优先从`~/hugegraph-download-url-prefix`指定的地址下载 tar 包；如果 -u 和`~/hugegraph-download-url-prefix`都没有时，会从默认下载地址 `https://github.com/hugegraph` 进行下载
 
 ##### 3.9 具体命令参数
 
@@ -261,6 +273,9 @@ Usage: hugegraph [options] [command] [command options]
       Default: hugegraph
     --password
       Password of user
+    --throw-mode
+      Whether the hugegraph-tools work to throw an exception
+      Default: false
     --timeout
       Connection timeout
       Default: 30
@@ -275,6 +290,25 @@ Usage: hugegraph [options] [command] [command options]
     --user
       Name of user
   Commands:
+    graph-create      Create graph with config
+      Usage: graph-create [options]
+        Options:
+          --file, -f
+            Creating graph config file
+          --name, -n
+            The name of new created graph, default is g
+            Default: g
+
+    graph-clone      Clone graph
+      Usage: graph-clone [options]
+        Options:
+          --clone-graph-name
+            The name of cloned graph, default is hugegraph
+            Default: hugegraph
+          --name, -n
+            The name of new created graph, default is g
+            Default: g
+
     graph-list      List all graphs
       Usage: graph-list
 
@@ -286,6 +320,13 @@ Usage: hugegraph [options] [command] [command options]
         Options:
         * --confirm-message, -c
             Confirm message of graph clear is "I'm sure to delete all data". 
+            (Note: include "")
+
+    graph-drop      Drop graph
+      Usage: graph-drop [options]
+        Options:
+        * --confirm-message, -c
+            Confirm message of graph clear is "I'm sure to drop the graph". 
             (Note: include "")
 
     graph-mode-set      Set graph mode
@@ -370,7 +411,7 @@ Usage: hugegraph [options] [command] [command options]
             Gremlin script to be executed, exclusive to --file
 
     backup      Backup graph schema/data. If directory is on HDFS, use -D to 
-            set HDFS params. For exmaple:
+            set HDFS params. For example: 
             -Dfs.default.name=hdfs://localhost:9000 
       Usage: backup [options]
         Options:
@@ -387,17 +428,19 @@ Usage: hugegraph [options] [command] [command options]
             File format, valid is [json, text]
             Default: json
           --huge-types, -t
-            Type of schema/data. Concat with ',' if more than one. 'all' means 
-            all vertices, edges and schema, in other words, 'all' equals with 
-            'vertex,edge,vertex_label,edge_label,property_key,index_label' 
+            Type of schema/data. Concat with ',' if more than one. Other types 
+            include 'all' and 'schema'. 'all' means all vertices, edges and 
+            schema. In other words, 'all' equals with 'vertex, edge, 
+            vertex_label, edge_label, property_key, index_label'. 'schema' 
+            equals with 'vertex_label, edge_label, property_key, index_label'.
             Default: [PROPERTY_KEY, VERTEX_LABEL, EDGE_LABEL, INDEX_LABEL, VERTEX, EDGE]
           --label
-            Vertex or edge label, only valid when type is vertex or edge
+            Vertex label or edge label, only valid when type is vertex or edge
           --log, -l
             Directory of log
             Default: ./logs
           --properties
-            Vertex or edge properties to backup, only valid when type is
+            Vertex or edge properties to backup, only valid when type is 
             vertex or edge
             Default: []
           --retry
@@ -406,6 +449,10 @@ Usage: hugegraph [options] [command] [command options]
           --split-size, -s
             Split size of shard
             Default: 1048576
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -444,6 +491,10 @@ Usage: hugegraph [options] [command] [command options]
           --split-size, -s
             Split size of shard
             Default: 1048576
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -451,7 +502,7 @@ Usage: hugegraph [options] [command] [command options]
 
     restore      Restore graph schema/data. If directory is on HDFS, use -D to 
             set HDFS params if needed. For 
-            exmaple:-Dfs.default.name=hdfs://localhost:9000 
+            example:-Dfs.default.name=hdfs://localhost:9000 
       Usage: restore [options]
         Options:
           --clean
@@ -461,9 +512,11 @@ Usage: hugegraph [options] [command] [command options]
             Directory of graph schema/data, default is './{graphname}' in 
             local file system or '{fs.default.name}/{graphname}' in HDFS
           --huge-types, -t
-            Type of schema/data. Concat with ',' if more than one. 'all' means 
-            all vertices, edges and schema, in other words, 'all' equals with 
-            'vertex,edge,vertex_label,edge_label,property_key,index_label' 
+            Type of schema/data. Concat with ',' if more than one. Other types 
+            include 'all' and 'schema'. 'all' means all vertices, edges and 
+            schema. In other words, 'all' equals with 'vertex, edge, 
+            vertex_label, edge_label, property_key, index_label'. 'schema' 
+            equals with 'vertex_label, edge_label, property_key, index_label'.
             Default: [PROPERTY_KEY, VERTEX_LABEL, EDGE_LABEL, INDEX_LABEL, VERTEX, EDGE]
           --log, -l
             Directory of log
@@ -471,6 +524,10 @@ Usage: hugegraph [options] [command] [command options]
           --retry
             Retry times, default is 3
             Default: 3
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -488,9 +545,11 @@ Usage: hugegraph [options] [command] [command options]
             Default: RESTORING
             Possible Values: [NONE, RESTORING, MERGING, LOADING]
           --huge-types, -t
-            Type of schema/data. Concat with ',' if more than one. 'all' means 
-            all vertices, edges and schema, in other words, 'all' equals with 
-            'vertex,edge,vertex_label,edge_label,property_key,index_label' 
+            Type of schema/data. Concat with ',' if more than one. Other types 
+            include 'all' and 'schema'. 'all' means all vertices, edges and 
+            schema. In other words, 'all' equals with 'vertex, edge, 
+            vertex_label, edge_label, property_key, index_label'. 'schema' 
+            equals with 'vertex_label, edge_label, property_key, index_label'.
             Default: [PROPERTY_KEY, VERTEX_LABEL, EDGE_LABEL, INDEX_LABEL, VERTEX, EDGE]
           --keep-local-data
             Whether to keep the local directory of graph data after restored
@@ -521,6 +580,10 @@ Usage: hugegraph [options] [command] [command options]
             Default: http://127.0.0.1:8081
           --target-user
             The username of target graph to migrate
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -553,9 +616,66 @@ Usage: hugegraph [options] [command] [command options]
     stop-all      Stop HugeGraph-Server and HugeGraph-Studio
       Usage: stop-all
 
+    auth-backup      null
+      Usage: auth-backup [options]
+        Options:
+          --directory
+            Directory of auth information, default is 
+            './{auth-backup-restore}' in local file system or 
+            '{fs.default.name}/{auth-backup-restore}' in HDFS
+          --retry
+            Retry times, default is 3
+            Default: 3
+          --types, -t
+            Type of auth data to restore and backup, concat with ',' if more 
+            than one. 'all' means all auth information. In other words, 'all' 
+            equals with 'user, group, target, belong, access'. In addition, 
+            'belong' or 'access' can not backup or restore alone, if type 
+            contains 'belong' then should contains 'user' and 'group'. If type 
+            contains 'access' then should contains 'group' and 'target'.
+            Default: [TARGET, GROUP, USER, ACCESS, BELONG]
+          -D
+            HDFS config parameters
+            Syntax: -Dkey=value
+            Default: {}
+
+    auth-restore      null
+      Usage: auth-restore [options]
+        Options:
+          --directory
+            Directory of auth information, default is 
+            './{auth-backup-restore}' in local file system or 
+            '{fs.default.name}/{auth-backup-restore}' in HDFS
+          --init-password
+            Init user password, if restore type include 'user', please specify 
+            the init-password of users.
+            Default: <empty string>
+          --retry
+            Retry times, default is 3
+            Default: 3
+          --strategy
+            The strategy needs to be chosen in the event of a conflict when 
+            restoring. Valid strategies include 'stop' and 'ignore', default 
+            is 'stop'. 'stop' means if there a conflict, stop restore. 
+            'ignore' means if there a conflict, ignore and continue to 
+            restore. 
+            Default: STOP
+            Possible Values: [STOP, IGNORE]
+          --types, -t
+            Type of auth data to restore and backup, concat with ',' if more 
+            than one. 'all' means all auth information. In other words, 'all' 
+            equals with 'user, group, target, belong, access'. In addition, 
+            'belong' or 'access' can not backup or restore alone, if type 
+            contains 'belong' then should contains 'user' and 'group'. If type 
+            contains 'access' then should contains 'group' and 'target'.
+            Default: [TARGET, GROUP, USER, ACCESS, BELONG]
+          -D
+            HDFS config parameters
+            Syntax: -Dkey=value
+            Default: {}
+
     help      Print usage
       Usage: help
-
 ```
 
 ##### 3.10 具体命令示例

--- a/content/en/docs/guides/backup-restore.md
+++ b/content/en/docs/guides/backup-restore.md
@@ -34,20 +34,20 @@ You can use [hugegraph-tools](/docs/quickstart/toolchain/hugegraph-tools) to bac
 bin/hugegraph backup -t all -d data
 ```
 
-This command backs up all the metadata and graph data of the hugegraph graph of http://127.0.0.1 to the data directory.
+This command backs up all the metadata and graph data of the hugegraph graph of http://127.0.0.1:8080 (the default --url) to the data directory.
 
-> Backup works fine in all three graph modes
+> Backup works in any graph mode, it does not check the graph mode
 
 #### Restore
 
-Restore has two modes: RESTORING and MERGING. Before backup, you must first set the graph mode according to your needs.
+Restore has two modes: RESTORING and MERGING. Before restore, you must first set the graph mode according to your needs, the restore command fails when the graph is in any other mode.
 
 ##### Step 1: View and set graph mode
 
 ```bash
 bin/hugegraph graph-mode-get
 ```
-This command is used to view the current graph mode, including: NONE, RESTORING, MERGING.
+This command is used to view the current graph mode, including: NONE, RESTORING, MERGING, LOADING.
 
 ```bash
 bin/hugegraph graph-mode-set -m RESTORING
@@ -60,7 +60,7 @@ This command is used to set the graph mode. Before Restore, it can be set to RES
 ```bash
 bin/hugegraph restore -t all -d data
 ```
-This command re-imports all metadata and graph data in the data directory to the hugegraph graph at http://127.0.0.1.
+This command re-imports all metadata and graph data in the data directory to the hugegraph graph at http://127.0.0.1:8080.
 
 ##### Step 3: Restoring Graph Mode
 

--- a/content/en/docs/quickstart/toolchain/hugegraph-tools.md
+++ b/content/en/docs/quickstart/toolchain/hugegraph-tools.md
@@ -26,6 +26,9 @@ export VERSION=1.7.0
 export ARCHIVE="apache-hugegraph-toolchain-incubating-${VERSION}"
 wget "https://downloads.apache.org/hugegraph/${VERSION}/${ARCHIVE}.tar.gz"
 tar zxf "${ARCHIVE}.tar.gz"
+# hugegraph-tools ships inside the toolchain package, in a directory
+# whose version suffix is the same as the archive's
+cd "${ARCHIVE}/apache-hugegraph-tools-incubating-${VERSION}"
 ```
 
 #### 2.2 Clone source code to compile and install
@@ -50,14 +53,14 @@ cd hugegraph-toolchain
 mvn package -pl hugegraph-tools -am -DskipTests -ntp
 ```
 
-Generate tar package hugegraph-tools-${version}.tar.gz
+The package is generated as `hugegraph-tools/target/apache-hugegraph-tools-${version}.tar.gz`, and the unpacked directory `hugegraph-tools/apache-hugegraph-tools-${version}` (containing `bin/` and `lib/`) is created next to it.
 
 
 ### 3 How to use
 
 #### 3.1 Function overview
 
-After decompression, enter the hugegraph-tools directory, you can use `bin/hugegraph` or `bin/hugegraph help` to view the usage information. mainly divided:
+After decompression, enter the apache-hugegraph-tools-${version} directory, you can use `bin/hugegraph` or `bin/hugegraph help` to view the usage information, and `bin/hugegraph help <sub-command>` to view the usage of a single sub-command. mainly divided:
 
 - Graph management type, graph-mode-set, graph-mode-get, graph-list, graph-get, graph-clear, graph-create, graph-clone and graph-drop
 - Asynchronous task management type, task-list, task-get, task-delete, task-cancel and task-clear
@@ -79,9 +82,11 @@ Usage: hugegraph [options] [command] [command options]
 - --user，When HugeGraph-Server opens authentication, pass username
 - --password，When HugeGraph-Server opens authentication, pass the user's password
 - --timeout，Timeout when connecting to HugeGraph-Server, the default is 30s
-- --protocol, connection protocol, either http or https; the default is http
 - --trust-store-file，The path of the certificate file, when --url uses https, the truststore file used by HugeGraph-Client, the default is empty, which means using the built-in truststore file conf/hugegraph.truststore of hugegraph-tools
 - --trust-store-password，The password of the certificate file, when --url uses https, the password of the truststore used by HugeGraph-Client, the default is empty, representing the password of the built-in truststore file of hugegraph-tools
+- --throw-mode, whether HugeGraph-Tools throws the exception instead of printing the error message and exiting, the default is false (mainly used by tests)
+
+> The protocol is taken from the scheme of --url: use `https://...` to connect over https. --trust-store-file and --trust-store-password can only be set when --url uses https, and both --user and --password must be given together or omitted together.
 
 The above global variables can also be set through environment variables. One way is to use export on the command line to set temporary environment variables, which are valid until the command line is closed
 
@@ -111,6 +116,8 @@ Another way is to set the environment variable in the bin/hugegraph script:
 #export HUGEGRAPH_TRUST_STORE_PASSWORD=
 ```
 
+`bin/hugegraph` also reads `JAVA_HOME` (a warning is printed when it is not set, and it is needed for https) and `JAVA_OPTIONS` (JVM options; when it is empty the script uses `-Xms512m` plus an `-Xmx` computed from the free memory of the machine).
+
 ##### 3.3 Graph Management Type, graph-mode-set, graph-mode-get, graph-list, graph-get, graph-clear, graph-create, graph-clone and graph-drop
 
 - graph-mode-set, set graph restore mode
@@ -121,27 +128,29 @@ Another way is to set the environment variable in the bin/hugegraph script:
 - graph-clear, clear all schema and data of a graph
   - --confirm-message or -c, required, delete confirmation information, manual input is required, double confirmation to prevent accidental deletion, "I'm sure to delete all data", including double quotes
 - graph-create, create a new graph with configuration file
-  - --name or -n, optional, the name of the new graph, default is hugegraph
-  - --file or -f, required, the path to the graph configuration file
+  - --name or -n, optional, the name of the new graph, default is g
+  - --file or -f, the path to the graph configuration file, the content of the file is sent to HugeGraph-Server as the config of the new graph
 - graph-clone, clone an existing graph
-  - --name or -n, optional, the name of the cloned graph, default is hugegraph
+  - --name or -n, optional, the name of the cloned graph, default is g
   - --clone-graph-name, optional, the name of the source graph to clone from, default is hugegraph
 - graph-drop, drop a graph (different from graph-clear, this completely removes the graph)
   - --confirm-message or -c, required, confirmation message "I'm sure to drop the graph", including double quotes
 
+> graph-create, graph-clone, graph-clear and graph-drop raise --timeout to at least 300 seconds.
+
 > When you need to restore the backup graph to a new graph, you need to set the graph mode to RESTORING mode; when you need to merge the backup graph into an existing graph, you need to first set the graph mode to MERGING model.
 
-##### 3.4 Asynchronous task management Type，task-list、task-get and task-delete
+##### 3.4 Asynchronous task management Type，task-list、task-get、task-delete、task-cancel and task-clear
 
 - task-list，List the asynchronous tasks in a graph, which can be filtered according to the status of the tasks
-  - --status，Optional, specify the status of the task to view, i.e. filter tasks by status
-  - --limit，Optional, specify the number of tasks to be obtained, the default is -1, which means to obtain all eligible tasks
+  - --status，Optional, specify the status of the task to view, i.e. filter tasks by status, legal values include [UNKNOWN, NEW, QUEUED, RESTORING, RUNNING, SUCCESS, CANCELLED, FAILED] (case insensitive)
+  - --limit，Optional, specify the number of tasks to be obtained, the default is -1, which means to obtain all eligible tasks, a value passed explicitly must be positive
 - task-get，Get detailed information about an asynchronous task
   - --task-id，Required, specifies the ID of the asynchronous task
 - task-delete，Delete information about an asynchronous task
   - --task-id，Required, specifies the ID of the asynchronous task
 - task-cancel，Cancel the execution of an asynchronous task
-  - --task-id，ID of the asynchronous task to cancel
+  - --task-id，Required, the ID of the asynchronous task to cancel
 - task-clear，Clean up completed asynchronous tasks
   - --force，Optional. When set, it means to clean up all asynchronous tasks. Unfinished ones are canceled first, and then all asynchronous tasks are cleared. By default, only completed asynchronous tasks are cleaned up
 
@@ -168,25 +177,27 @@ Another way is to set the environment variable in the bin/hugegraph script:
 - backup, back up the schema or data in a certain graph out of the HugeGraph system, and store it on the local disk or HDFS in the form of JSON
   - --format, the backup format, optional values include [json, text], the default is json
   - --all-properties, whether to back up all properties of vertices/edges, only valid when --format is text, default false
-  - --label, the type of vertices/edges to be backed up, only valid when --format is text, only valid when backing up vertices or edges
+  - --label, the vertex label or edge label to be backed up, only applied when --format is text; when it is set, --huge-types must name exactly one type and that type must be vertex or edge, otherwise the command fails
   - --properties, properties of vertices/edges to be backed up, separated by commas, only valid when --format is text, valid only when backing up vertices or edges
   - --compress, whether to compress data during backup, the default is true
   - --directory or -d, the directory to store schema or data, the default is './{graphName}' for local directory, and '{fs.default.name}/{graphName}' for HDFS
-  - --huge-types or -t, the data types to be backed up, separated by commas, the optional value is 'all' or a combination of one or more [vertex, edge, vertex_label, edge_label, property_key, index_label], 'all' Represents all 6 types, namely vertices, edges and all schemas
-  - --log or -l, specify the log directory, the default is the current directory
+  - --huge-types or -t, the data types to be backed up, separated by commas, the optional value is 'all' or a combination of one or more [vertex, edge, vertex_label, edge_label, property_key, index_label], 'all' Represents all 6 types, namely vertices, edges and all schemas, 'schema' represents the 4 schema types [vertex_label, edge_label, property_key, index_label]
+  - --log or -l, specify the log directory, the default is ./logs
   - --retry, specify the number of failed retries, the default is 3
   - --thread-num or -T, the number of threads to use, default is Math.min(10, Math.max(4, CPUs / 2))
-  - --split-size or -s, specifies the size of splitting vertices or edges when backing up, the default is 1048576
+  - --split-size or -s, specifies the size of splitting vertices or edges when backing up, the default is 1048576, and it must be at least 1048576 (1M)
   - -D, use the mode of -Dkey=value to specify dynamic parameters, and specify HDFS configuration items when backing up data to HDFS, for example: -Dfs.default.name=hdfs://localhost:9000
+  > If --timeout is less than 120 seconds, backup (and the backup step of migrate) uses 120 seconds
 - restore, restore schema or data stored in JSON format to a new graph (RESTORING mode) or merge into an existing graph (MERGING mode)
   - --directory or -d, the directory to store schema or data, the default is './{graphName}' for local directory, and '{fs.default.name}/{graphName}' for HDFS
   - --clean, whether to delete the directory specified by --directory after the recovery map is completed, the default is false
-  - --huge-types or -t, data types to restore, separated by commas, optional value is 'all' or a combination of one or more [vertex, edge, vertex_label, edge_label, property_key, index_label], 'all' Represents all 6 types, namely vertices, edges and all schemas
-  - --log or -l, specify the log directory, the default is the current directory
+  - --huge-types or -t, data types to restore, separated by commas, optional value is 'all' or a combination of one or more [vertex, edge, vertex_label, edge_label, property_key, index_label], 'all' Represents all 6 types, namely vertices, edges and all schemas, 'schema' represents the 4 schema types [vertex_label, edge_label, property_key, index_label]
+  - --log or -l, specify the log directory, the default is ./logs
   - --retry, specify the number of failed retries, the default is 3
   - --thread-num or -T, the number of threads to use, default is Math.min(10, Math.max(4, CPUs / 2))
   - -D, use the mode of -Dkey=value to specify dynamic parameters, which are used to specify HDFS configuration items when restoring graphs from HDFS, for example: -Dfs.default.name=hdfs://localhost:9000
   > restore command can be used only if --format is executed as backup for json
+  > restore requires the graph to be in RESTORING or MERGING mode (set it with graph-mode-set first), otherwise the command fails
 - migrate, migrate the currently connected graph to another HugeGraphServer
   - --target-graph, the name of the target graph, the default is hugegraph
   - --target-url, the HugeGraphServer where the target graph is located, the default is http://127.0.0.1:8081
@@ -196,60 +207,61 @@ Another way is to set the environment variable in the bin/hugegraph script:
   - --target-trust-store-file, access the truststore file used by the target graph
   - --target-trust-store-password, the password to access the truststore used by the target map
   - --directory or -d, during the migration process, the directory where the schema or data of the source graph is stored. For a local directory, the default is './{graphName}'; for HDFS, the default is '{fs.default.name}/ {graphName}'
-  - --huge-types or -t, the data types to be migrated, separated by commas, the optional value is 'all' or a combination of one or more [vertex, edge, vertex_label, edge_label, property_key, index_label], 'all' Represents all 6 types, namely vertices, edges and all schemas
-  - --log or -l, specify the log directory, the default is the current directory
+  - --huge-types or -t, the data types to be migrated, separated by commas, the optional value is 'all' or a combination of one or more [vertex, edge, vertex_label, edge_label, property_key, index_label], 'all' Represents all 6 types, namely vertices, edges and all schemas, 'schema' represents the 4 schema types [vertex_label, edge_label, property_key, index_label]
+  - --log or -l, specify the log directory, the default is ./logs
   - --retry, specify the number of failed retries, the default is 3
-  - --split-size or -s, specify the size of the vertex or edge block when backing up the source graph during the migration process, the default is 1048576
+  - --thread-num or -T, the number of threads to use, default is Math.min(10, Math.max(4, CPUs / 2))
+  - --split-size or -s, specify the size of the vertex or edge block when backing up the source graph during the migration process, the default is 1048576, and it must be at least 1048576 (1M)
   - -D, use the mode of -Dkey=value to specify dynamic parameters, which are used to specify HDFS configuration items when the data needs to be backed up to HDFS during the migration process, for example: -Dfs.default.name=hdfs://localhost: 9000
-  - --graph-mode or -m, the mode to set the target graph when restoring the source graph to the target graph, legal values include [RESTORING, MERGING]
+  - --graph-mode or -m, the mode to set the target graph when restoring the source graph to the target graph, legal values include [RESTORING, MERGING], the default is RESTORING. The target graph is switched to this mode during the migration and switched back to its original mode afterwards
   - --keep-local-data, whether to keep the backup of the source map generated in the process of migrating the map, the default is false, that is, the backup of the source map is not kept after the default migration map ends
 - schedule-backup, periodically back up the graph and keep a certain number of the latest backups (currently only supports local file systems)
   - --directory or -d, required, specifies the directory of the backup data
   - --backup-num, optional, specifies the number of latest backups to save, defaults to 3
-  - --interval, an optional item, specifies the backup cycle, the format is the same as the Linux crontab format
+  - --interval, an optional item, specifies the backup cycle, the format is the same as the Linux crontab format, the default is "0 0 * * *" (every day at 00:00)
+  > schedule-backup adds a crontab entry that runs `backup -t all` into `{directory}/{graph}/hugegraph-backup-{yyMMddHHmm}/` and keeps only the latest --backup-num backups. A relative --directory is resolved against the hugegraph-tools home directory, and `{directory}/{graph}` must not exist yet
 - dump, export all vertices and edges in the graph, using the `vertex vertex-edge1 vertex-edge2...` JSON format by default.
   To customize the format, implement a `Formatter` subclass such as `CustomFormatter` under `hugegraph-tools/src/main/java/org/apache/hugegraph/formatter`, then select it when running the command:
   `bin/hugegraph dump -f CustomFormatter`
   - --formatter or -f, specify the formatter to use, the default is JsonFormatter
-  - --directory or -d, the directory where schema or data is stored, the default is the current directory
-  - --log or -l, specify the log directory, the default is the current directory
+  - --directory or -d, the directory where schema or data is stored, the default is './{graphName}' for local directory, and '{fs.default.name}/{graphName}' for HDFS
+  - --log or -l, specify the log directory, the default is ./logs
   - --retry, specify the number of failed retries, the default is 3
-  - --split-size or -s, specifies the size of splitting vertices or edges when backing up, the default is 1048576
+  - --thread-num or -T, the number of threads to use, default is Math.min(10, Math.max(4, CPUs / 2))
+  - --split-size or -s, specifies the size of splitting vertices or edges when backing up, the default is 1048576, and it must be at least 1048576 (1M)
   - -D, use the mode of -Dkey=value to specify dynamic parameters, and specify HDFS configuration items when backing up data to HDFS, for example: -Dfs.default.name=hdfs://localhost:9000
 
 ##### 3.7 Authentication data backup/restore type
 
 - auth-backup, backup authentication data to a specified directory
-  - --types or -t, types of authentication data to back up, separated by commas, optional value is 'all' or a combination of one or more [user, group, target, belong, access], 'all' represents all 5 types
-  - --directory or -d, directory to store backup data, defaults to current directory
-  - --log or -l, specify the log directory, the default is the current directory
+  - --types or -t, types of authentication data to back up, separated by commas, optional value is 'all' or a combination of one or more [user, group, target, belong, access], 'all' represents all 5 types; 'belong' requires 'user' and 'group' to be included, 'access' requires 'group' and 'target' to be included
+  - --directory, directory to store backup data, the default is './auth-backup-restore' for local directory, and '{fs.default.name}/auth-backup-restore' for HDFS (this option has no -d short form)
   - --retry, specify the number of failed retries, the default is 3
-  - --thread-num or -T, the number of threads to use, default is Math.min(10, Math.max(4, CPUs / 2))
   - -D, use the mode of -Dkey=value to specify dynamic parameters, and specify HDFS configuration items when backing up data to HDFS, for example: -Dfs.default.name=hdfs://localhost:9000
 - auth-restore, restore authentication data from a specified directory
-  - --types or -t, types of authentication data to restore, separated by commas, optional value is 'all' or a combination of one or more [user, group, target, belong, access], 'all' represents all 5 types
-  - --directory or -d, directory where backup data is stored, defaults to current directory
-  - --log or -l, specify the log directory, the default is the current directory
+  - --types or -t, types of authentication data to restore, separated by commas, optional value is 'all' or a combination of one or more [user, group, target, belong, access], 'all' represents all 5 types; 'belong' requires 'user' and 'group' to be included, 'access' requires 'group' and 'target' to be included
+  - --directory, directory where backup data is stored, the default is './auth-backup-restore' for local directory, and '{fs.default.name}/auth-backup-restore' for HDFS (this option has no -d short form)
   - --retry, specify the number of failed retries, the default is 3
-  - --thread-num or -T, the number of threads to use, default is Math.min(10, Math.max(4, CPUs / 2))
   - --strategy, conflict handling strategy, optional values are [stop, ignore], default is stop. stop means stop restoring when encountering conflicts, ignore means ignore conflicts and continue restoring
-  - --init-password, initial password to set when restoring users, required when restoring user data
+  - --init-password, initial password to set when restoring users, required when --types includes user
   - -D, use the mode of -Dkey=value to specify dynamic parameters, which are used to specify HDFS configuration items when restoring data from HDFS, for example: -Dfs.default.name=hdfs://localhost:9000
 
 ##### 3.8 Install the deployment type
 
 - deploy, one-click download, install and start HugeGraph-Server and HugeGraph-Studio
-  - -v, required, specifies the HugeGraph-Server and HugeGraph-Studio version to install
+  - -v, required, specifies the HugeGraph-Server and HugeGraph-Studio version to install, must be one of the versions listed in bin/version-map.yaml (0.6, 0.7, 0.8, 0.9, 0.10), which maps it to the matching server and studio release versions
   - -p, required, specifies the installed HugeGraph-Server and HugeGraph-Studio directories
   - -u, optional, specifies the link to download the HugeGraph-Server and HugeGraph-Studio compressed packages
-- clear, clean up HugeGraph-Server and HugeGraph-Studio directories and tarballs
+- clear, clean up HugeGraph-Server and HugeGraph-Studio directories and tarballs (refuses to run while a matching server or studio process is still alive, and prompts before each removal)
   - -p, required, specifies the directory of HugeGraph-Server and HugeGraph-Studio to be cleaned
-- start-all, start HugeGraph-Server and HugeGraph-Studio with one click, and start monitoring, automatically pull up the service when the service dies
-  - -v, required, specifies the installed HugeGraph-Server and HugeGraph-Studio version to start
+- start-all, start HugeGraph-Server and HugeGraph-Studio with one click
+  - -v, required, specifies the installed HugeGraph-Server and HugeGraph-Studio version to start, same values as deploy
   - -p, required, specifies the directory where HugeGraph-Server and HugeGraph-Studio are installed
 - stop-all, close HugeGraph-Server and HugeGraph-Studio with one click
 
-> There is an optional parameter -u in the deploy command. When provided, the specified download address will be used instead of the default download address to download the tar package, and the address will be written into the `~/hugegraph-download-url-prefix` file; if no address is specified later When -u and `~/hugegraph-download-url-prefix` are not specified, the tar package will be downloaded from the address specified by `~/hugegraph-download-url-prefix`; if there is neither -u nor `~/hugegraph-download-url-prefix`, it will be downloaded from the default download address
+> deploy, start-all, clear and stop-all are handed by `bin/hugegraph` straight to the shell scripts `bin/deploy.sh`, `bin/start-all.sh`, `bin/clear.sh` and `bin/stop-all.sh`, so the global options and environment variables in 3.2 do not apply to them.
+
+> There is an optional parameter -u in the deploy command. When provided, the specified download address will be used instead of the default download address to download the tar package, and the address will be written into the `~/hugegraph-download-url-prefix` file; if no address is specified later When -u and `~/hugegraph-download-url-prefix` are not specified, the tar package will be downloaded from the address specified by `~/hugegraph-download-url-prefix`; if there is neither -u nor `~/hugegraph-download-url-prefix`, it will be downloaded from the default download address `https://github.com/hugegraph`
 
 ##### 3.9 Specific command parameters
 
@@ -263,6 +275,9 @@ Usage: hugegraph [options] [command] [command options]
       Default: hugegraph
     --password
       Password of user
+    --throw-mode
+      Whether the hugegraph-tools work to throw an exception
+      Default: false
     --timeout
       Connection timeout
       Default: 30
@@ -277,6 +292,25 @@ Usage: hugegraph [options] [command] [command options]
     --user
       Name of user
   Commands:
+    graph-create      Create graph with config
+      Usage: graph-create [options]
+        Options:
+          --file, -f
+            Creating graph config file
+          --name, -n
+            The name of new created graph, default is g
+            Default: g
+
+    graph-clone      Clone graph
+      Usage: graph-clone [options]
+        Options:
+          --clone-graph-name
+            The name of cloned graph, default is hugegraph
+            Default: hugegraph
+          --name, -n
+            The name of new created graph, default is g
+            Default: g
+
     graph-list      List all graphs
       Usage: graph-list
 
@@ -288,6 +322,13 @@ Usage: hugegraph [options] [command] [command options]
         Options:
         * --confirm-message, -c
             Confirm message of graph clear is "I'm sure to delete all data". 
+            (Note: include "")
+
+    graph-drop      Drop graph
+      Usage: graph-drop [options]
+        Options:
+        * --confirm-message, -c
+            Confirm message of graph clear is "I'm sure to drop the graph". 
             (Note: include "")
 
     graph-mode-set      Set graph mode
@@ -372,7 +413,7 @@ Usage: hugegraph [options] [command] [command options]
             Gremlin script to be executed, exclusive to --file
 
     backup      Backup graph schema/data. If directory is on HDFS, use -D to 
-            set HDFS params. For exmaple:
+            set HDFS params. For example: 
             -Dfs.default.name=hdfs://localhost:9000 
       Usage: backup [options]
         Options:
@@ -389,17 +430,19 @@ Usage: hugegraph [options] [command] [command options]
             File format, valid is [json, text]
             Default: json
           --huge-types, -t
-            Type of schema/data. Concat with ',' if more than one. 'all' means 
-            all vertices, edges and schema, in other words, 'all' equals with 
-            'vertex,edge,vertex_label,edge_label,property_key,index_label' 
+            Type of schema/data. Concat with ',' if more than one. Other types 
+            include 'all' and 'schema'. 'all' means all vertices, edges and 
+            schema. In other words, 'all' equals with 'vertex, edge, 
+            vertex_label, edge_label, property_key, index_label'. 'schema' 
+            equals with 'vertex_label, edge_label, property_key, index_label'.
             Default: [PROPERTY_KEY, VERTEX_LABEL, EDGE_LABEL, INDEX_LABEL, VERTEX, EDGE]
           --label
-            Vertex or edge label, only valid when type is vertex or edge
+            Vertex label or edge label, only valid when type is vertex or edge
           --log, -l
             Directory of log
             Default: ./logs
           --properties
-            Vertex or edge properties to backup, only valid when type is
+            Vertex or edge properties to backup, only valid when type is 
             vertex or edge
             Default: []
           --retry
@@ -408,6 +451,10 @@ Usage: hugegraph [options] [command] [command options]
           --split-size, -s
             Split size of shard
             Default: 1048576
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -446,6 +493,10 @@ Usage: hugegraph [options] [command] [command options]
           --split-size, -s
             Split size of shard
             Default: 1048576
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -453,7 +504,7 @@ Usage: hugegraph [options] [command] [command options]
 
     restore      Restore graph schema/data. If directory is on HDFS, use -D to 
             set HDFS params if needed. For 
-            exmaple:-Dfs.default.name=hdfs://localhost:9000 
+            example:-Dfs.default.name=hdfs://localhost:9000 
       Usage: restore [options]
         Options:
           --clean
@@ -463,9 +514,11 @@ Usage: hugegraph [options] [command] [command options]
             Directory of graph schema/data, default is './{graphname}' in 
             local file system or '{fs.default.name}/{graphname}' in HDFS
           --huge-types, -t
-            Type of schema/data. Concat with ',' if more than one. 'all' means 
-            all vertices, edges and schema, in other words, 'all' equals with 
-            'vertex,edge,vertex_label,edge_label,property_key,index_label' 
+            Type of schema/data. Concat with ',' if more than one. Other types 
+            include 'all' and 'schema'. 'all' means all vertices, edges and 
+            schema. In other words, 'all' equals with 'vertex, edge, 
+            vertex_label, edge_label, property_key, index_label'. 'schema' 
+            equals with 'vertex_label, edge_label, property_key, index_label'.
             Default: [PROPERTY_KEY, VERTEX_LABEL, EDGE_LABEL, INDEX_LABEL, VERTEX, EDGE]
           --log, -l
             Directory of log
@@ -473,6 +526,10 @@ Usage: hugegraph [options] [command] [command options]
           --retry
             Retry times, default is 3
             Default: 3
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -490,9 +547,11 @@ Usage: hugegraph [options] [command] [command options]
             Default: RESTORING
             Possible Values: [NONE, RESTORING, MERGING, LOADING]
           --huge-types, -t
-            Type of schema/data. Concat with ',' if more than one. 'all' means 
-            all vertices, edges and schema, in other words, 'all' equals with 
-            'vertex,edge,vertex_label,edge_label,property_key,index_label' 
+            Type of schema/data. Concat with ',' if more than one. Other types 
+            include 'all' and 'schema'. 'all' means all vertices, edges and 
+            schema. In other words, 'all' equals with 'vertex, edge, 
+            vertex_label, edge_label, property_key, index_label'. 'schema' 
+            equals with 'vertex_label, edge_label, property_key, index_label'.
             Default: [PROPERTY_KEY, VERTEX_LABEL, EDGE_LABEL, INDEX_LABEL, VERTEX, EDGE]
           --keep-local-data
             Whether to keep the local directory of graph data after restored
@@ -523,6 +582,10 @@ Usage: hugegraph [options] [command] [command options]
             Default: http://127.0.0.1:8081
           --target-user
             The username of target graph to migrate
+          --thread-num, -T
+            Threads number to use, default is Math.min(10, Math.max(4, CPUs / 
+            2)) 
+            Default: 0
           -D
             HDFS config parameters
             Syntax: -Dkey=value
@@ -555,9 +618,66 @@ Usage: hugegraph [options] [command] [command options]
     stop-all      Stop HugeGraph-Server and HugeGraph-Studio
       Usage: stop-all
 
+    auth-backup      null
+      Usage: auth-backup [options]
+        Options:
+          --directory
+            Directory of auth information, default is 
+            './{auth-backup-restore}' in local file system or 
+            '{fs.default.name}/{auth-backup-restore}' in HDFS
+          --retry
+            Retry times, default is 3
+            Default: 3
+          --types, -t
+            Type of auth data to restore and backup, concat with ',' if more 
+            than one. 'all' means all auth information. In other words, 'all' 
+            equals with 'user, group, target, belong, access'. In addition, 
+            'belong' or 'access' can not backup or restore alone, if type 
+            contains 'belong' then should contains 'user' and 'group'. If type 
+            contains 'access' then should contains 'group' and 'target'.
+            Default: [TARGET, GROUP, USER, ACCESS, BELONG]
+          -D
+            HDFS config parameters
+            Syntax: -Dkey=value
+            Default: {}
+
+    auth-restore      null
+      Usage: auth-restore [options]
+        Options:
+          --directory
+            Directory of auth information, default is 
+            './{auth-backup-restore}' in local file system or 
+            '{fs.default.name}/{auth-backup-restore}' in HDFS
+          --init-password
+            Init user password, if restore type include 'user', please specify 
+            the init-password of users.
+            Default: <empty string>
+          --retry
+            Retry times, default is 3
+            Default: 3
+          --strategy
+            The strategy needs to be chosen in the event of a conflict when 
+            restoring. Valid strategies include 'stop' and 'ignore', default 
+            is 'stop'. 'stop' means if there a conflict, stop restore. 
+            'ignore' means if there a conflict, ignore and continue to 
+            restore. 
+            Default: STOP
+            Possible Values: [STOP, IGNORE]
+          --types, -t
+            Type of auth data to restore and backup, concat with ',' if more 
+            than one. 'all' means all auth information. In other words, 'all' 
+            equals with 'user, group, target, belong, access'. In addition, 
+            'belong' or 'access' can not backup or restore alone, if type 
+            contains 'belong' then should contains 'user' and 'group'. If type 
+            contains 'access' then should contains 'group' and 'target'.
+            Default: [TARGET, GROUP, USER, ACCESS, BELONG]
+          -D
+            HDFS config parameters
+            Syntax: -Dkey=value
+            Default: {}
+
     help      Print usage
       Usage: help
-
 ```
 
 ##### 3.10 Specific command example


### PR DESCRIPTION
## Purpose of the PR

Sync the hugegraph-tools docs (en + cn) with hugegraph-toolchain master (3b385c3d).

The pages had drifted from the CLI: they documented a global option that is not registered, missed one global option and several sub-command options, listed options on the auth commands that do not exist there, and carried several wrong defaults. The usage block was also missing three graph sub-commands and both auth sub-commands.

| Page | What was wrong | What changed | Source on master |
|------|----------------|--------------|------------------|
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--protocol` listed as a global option, but it is never registered on the main command | Removed it; replaced with a note that the protocol comes from the `--url` scheme | hugegraph-tools/src/main/java/org/apache/hugegraph/cmd/HugeGraphCommand.java:62-86, base/ToolClient.java:51 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--throw-mode` global option not documented | Added it with its `false` default | cmd/SubCommands.java:753-759 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--trust-store-file` / `--trust-store-password` had no stated constraint; `--user` / `--password` pairing not stated | Added a note that the truststore options require an https `--url`, and that user and password must both be set or both omitted | base/ToolClient.java:51-70, cmd/HugeGraphCommand.java:411-414 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `JAVA_HOME` and `JAVA_OPTIONS` not mentioned | Added a line describing both, including the computed `-Xmx` | hugegraph-tools/assembly/bin/hugegraph:47-52, 136-143 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | graph-create `--name` default given as `hugegraph`, and `--file` marked required | Default corrected to `g`; `--file` is optional and its content is sent as the graph config | cmd/SubCommands.java:377-382, 831-837 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | graph-clone `--name` default given as `hugegraph`, and `--clone-graph-name` missing | Default corrected to `g`; added `--clone-graph-name` with default `hugegraph` | cmd/SubCommands.java:396-402 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | Nothing said about the timeout floor on the graph sub-commands | Added a note that graph-create, graph-clone, graph-clear and graph-drop raise `--timeout` to at least 300 seconds | cmd/HugeGraphCommand.java:55-56, 268, 277, 297, 306 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | Section 3.4 heading omitted task-cancel and task-clear | Heading updated to list all five task sub-commands | cmd/SubCommands.java:69-73 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | task-list `--status` had no value list; `--limit` had no positivity note; task-cancel `--task-id` not marked required | Added the eight legal statuses, the positive-value rule, and the required marker | manager/TasksManager.java:31-34, cmd/SubCommands.java:888-909, 1247-1257 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--huge-types` list omitted the `schema` value | Added `schema` and what it expands to for backup, restore and migrate | cmd/SubCommands.java:761-773, 1039-1054 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--log` default given as the current directory | Corrected to `./logs` | cmd/SubCommands.java:638-640 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--thread-num` / `-T` missing from backup, restore, migrate and dump | Added with the `Math.min(10, Math.max(4, CPUs / 2))` default | cmd/SubCommands.java:642-646, base/RetryManager.java:33-34 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | `--split-size` had no minimum | Added the 1048576 (1M) minimum on backup, migrate and dump | manager/BackupManager.java:110-113 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | backup `--label` described only as applying to vertex/edge backups | Restated the enforced rule: `--huge-types` must name exactly one type, vertex or edge | manager/BackupManager.java:98-105 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | Nothing said about the backup timeout floor | Added a note that a `--timeout` below 120 seconds is raised to 120 for backup and for the backup step of migrate | manager/BackupManager.java:67, cmd/HugeGraphCommand.java:188-190, 220-222 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | restore did not say which graph modes it requires | Added a note that the graph must be in RESTORING or MERGING | cmd/HugeGraphCommand.java:200-203, hugegraph-client/src/main/java/org/apache/hugegraph/structure/constant/GraphMode.java:85-87 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | migrate `--graph-mode` had no default and no note about the mode swap | Added the RESTORING default and the switch-back behaviour | cmd/SubCommands.java:310-314, cmd/HugeGraphCommand.java:236-255 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | schedule-backup `--interval` had no default, and the crontab behaviour was undocumented | Added the `"0 0 * * *"` default plus a note on the crontab entry, the backup path, the retention and the relative-path rule | cmd/SubCommands.java:102-119, assembly/bin/schedule-backup.sh:29-134, assembly/bin/backup.sh:29-37 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | dump `--directory` default given as the current directory | Corrected to `./{graphName}` locally and `{fs.default.name}/{graphName}` on HDFS | cmd/SubCommands.java:632-636, base/LocalDirectory.java:138-142, base/HdfsDirectory.java:176-190 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | auth-backup / auth-restore listed `--log` and `--thread-num`, which they do not accept, and gave `-d` as a short form of `--directory` | Removed both options and the `-d` short form; corrected the directory default to `./auth-backup-restore` | cmd/SubCommands.java:912-926 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | auth `--types` did not state the belong/access dependencies; `--init-password` condition was vague | Added the dependency rules and the exact condition on `--types` containing `user` | cmd/SubCommands.java:1003-1016, 1088-1097, manager/AuthBackupRestoreManager.java:228-233 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | deploy / start-all `-v` had no value list; clear did not describe its guards; the default download prefix was not named | Added the version-map values, the running-process and prompt guards, and the default prefix | assembly/bin/version-map.yaml:19-42, assembly/bin/deploy.sh:22, 76-80, assembly/bin/clear.sh:64-93 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | Nothing said that the install sub-commands bypass the Java CLI | Added a note that deploy, start-all, clear and stop-all are handed to the shell scripts, so the global options do not apply | assembly/bin/hugegraph:54-75 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | Usage block was missing graph-create, graph-clone, graph-drop, auth-backup and auth-restore, and carried stale option text and a typo | Refreshed the block against the current parameter definitions | cmd/SubCommands.java:59-93, 122-125, 215-218, 763-773 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-tools.md | Build output described as `hugegraph-tools-${version}.tar.gz`, and the release-package layout was not given | Corrected to `apache-hugegraph-tools-${version}.tar.gz` plus the unpacked directory, and added the path to the tools directory inside the toolchain package | hugegraph-tools/pom.xml:34-38, 181-215, hugegraph-tools/assembly/descriptor/assembly.xml:18-48, hugegraph-dist/pom.xml:33-60 |
| content/{en,cn}/docs/guides/backup-restore.md | Server address given as `http://127.0.0.1` | Corrected to `http://127.0.0.1:8080`, the actual `--url` default | cmd/SubCommands.java:694-697 |
| content/{en,cn}/docs/guides/backup-restore.md | Said backup works in "all three graph modes" and listed three modes for graph-mode-get | There are four modes; backup does not check the mode at all, while restore requires RESTORING or MERGING | hugegraph-client/src/main/java/org/apache/hugegraph/structure/constant/GraphMode.java:24-87, cmd/HugeGraphCommand.java:187-203 |

Scope note: only the hugegraph-tools parts of the backup/restore guide were touched.

Paths in the "Source on master" column are relative to `hugegraph-tools/` unless stated otherwise.
