### PR TITLE
doc(toolchain): sync client with master

### DIFF
--- a/content/cn/docs/clients/hugegraph-client.md
+++ b/content/cn/docs/clients/hugegraph-client.md
@@ -29,6 +29,51 @@ HugeClient hugeClient = HugeClient.builder("http://localhost:8080", "hugegraph")
 
 在`HugeGraph - Hubble`中通过`gremlin`来操作时，不需要使用`HugeClient`，可以忽略。
 
+#### 1.1 构造器选项
+
+构造器支持下列选项。所有超时参数的单位都是秒，内部会转换为毫秒。
+
+| interface                                                    | description                                        | default            |
+|--------------------------------------------------------------|----------------------------------------------------|--------------------|
+| `configUrl(String url)`                                       | 服务端地址，通常已经通过 `builder(...)` 传入        | 必填               |
+| `configGraph(String graph)`                                   | 图名称，通常已经通过 `builder(...)` 传入            | 必填               |
+| `configGraphSpace(String graphSpace)`                         | GraphSpace 名称，传入 null 或空值时回退为 `DEFAULT` | `DEFAULT`          |
+| `configUser(String username, String password)`                | 服务端用户名和密码，传入 null 时按空字符串处理      | 空，不开启认证     |
+| `configToken(String token)`                                   | 使用 Token 代替用户名和密码                         | 空                 |
+| `configTimeout(int seconds)`                                  | 请求超时，传入 `0` 时恢复默认值                     | 20                 |
+| `configConnectTimeout(Integer seconds)`                       | 连接超时，不设置时沿用 `configTimeout`              | 未设置             |
+| `configReadTimeout(Integer seconds)`                          | 读取超时，不设置时沿用 `configTimeout`              | 未设置             |
+| `configPool(int maxConns, int maxConnsPerRoute)`              | 连接池大小，任意一项传入 `0` 时恢复其默认值         | 4 x CPU 数，2 x CPU 数 |
+| `configIdleTime(int seconds)`                                 | 空闲连接保持时间，必须大于 0                        | 30                 |
+| `configSSL(String trustStoreFile, String trustStorePassword)` | HTTPS 连接使用的信任库                              | 空                 |
+| `configHttpBuilder(Consumer<OkHttpClient.Builder> consumer)`  | 回调，用于进一步定制底层的 OkHttp 客户端            | 无                 |
+| `graphRequired(boolean graphRequired)`                        | `build()` 是否拒绝空的 url 或图名称                 | true               |
+
+调用 `build()` 时，客户端会读取服务端的 API 版本，超出 `[0.38, 0.81)` 范围时报错。
+
+#### 1.2 操作入口
+
+除 schema、graph 和 gremlin 外，HugeClient 还提供下列入口。图级别的入口只有在指定了图名称时才可用；如果创建客户端时图名称为空，这些入口会返回 null，直到调用 `assignGraph(graphSpace, graph)` 为止。
+
+| interface             | returns                | scope      | description                                                |
+|-----------------------|------------------------|------------|------------------------------------------------------------|
+| `schema()`            | `SchemaManager`        | graph      | 管理 PropertyKey、VertexLabel、EdgeLabel 和 IndexLabel      |
+| `graph()`             | `GraphManager`         | graph      | 单条或批量地增删改查顶点和边                                |
+| `gremlin()`           | `GremlinManager`       | graph      | 同步执行 Gremlin 语句，或作为异步任务提交                    |
+| `cypher()`            | `CypherManager`        | graph      | 同步执行 Cypher 语句，或作为异步任务提交                     |
+| `traverser()`         | `TraverserManager`     | graph      | RESTful 遍历，如最短路径、k-out、k-neighbor、交叉点等         |
+| `variables()`         | `VariablesManager`     | graph      | 获取、设置、列出和删除图变量                                 |
+| `job()`               | `JobManager`           | graph      | 重建 VertexLabel、EdgeLabel 或 IndexLabel 的索引             |
+| `task()`              | `TaskManager`          | graph      | 列出、获取、取消、删除异步任务，或等待其完成                  |
+| `computer()`          | `ComputerManager`      | graph      | 创建、取消、列出和获取 computer 任务                         |
+| `graphs()`            | `GraphsManager`        | graphspace | 创建、克隆、列出、重载、清空和删除图，读取和设置图的模式      |
+| `graphSpace()`        | `GraphSpaceManager`    | server     | 管理 GraphSpace，详见第 4 节                                 |
+| `auth()`              | `AuthManager`          | server     | 管理 user、group、target、belong 和 access                   |
+| `metrics()`           | `MetricsManager`       | server     | 读取后端、系统和统计指标                                     |
+| `versionManager()`    | `VersionManager`       | server     | 读取服务端的 core、gremlin 和 API 版本                        |
+
+客户端还会报告所连服务端支持的能力，调用方可以据此判断，而不必解析版本号：`supportsGraphSpace()`、`supportsCypher()`、`supportsGraphCreate()`、`supportsDefaultRole()` 和 `isServerAuthEnabled()`。
+
 ### 2 元数据
 
 #### 2.1 SchemaManager
@@ -55,7 +100,7 @@ schema = graph.schema()
 
 PropertyKey 用来规范顶点和边的属性的约束，暂不支持定义属性的属性。
 
-PropertyKey 允许定义的约束信息包括：name、datatype、cardinality、userdata，下面逐一介绍。
+PropertyKey 允许定义的约束信息包括：name、datatype、cardinality、aggregateType、writeType、userdata，下面逐一介绍。
 
 - name: 属性的名字，用来区分不同的 PropertyKey，不允许有同名的属性；
 
@@ -70,7 +115,7 @@ PropertyKey 允许定义的约束信息包括：name、datatype、cardinality、
 | asText()    | String     |
 | asInt()     | Integer    |
 | asDate()    | Date       |
-| asUuid()    | UUID       |
+| asUUID()    | UUID       |
 | asBoolean() | Boolean    |
 | asByte()    | Byte       |
 | asBlob()    | Byte[]     |
@@ -85,6 +130,31 @@ PropertyKey 允许定义的约束信息包括：name、datatype、cardinality、
 | valueSingle() | single      | single value                                |
 | valueList()   | list        | multi-values that allow duplicate value     |
 | valueSet()    | set         | multi-values that not allow duplicate value |
+
+- aggregateType：同一属性被重复写入时的合并方式，默认为 none，即保留最后写入的值。数值类的选项要求属性为数字类型；
+
+| interface   | aggregateType | description        |
+|-------------|---------------|--------------------|
+| calcSum()   | sum           | 对写入的值累加      |
+| calcMax()   | max           | 保留最大值          |
+| calcMin()   | min           | 保留最小值          |
+| calcOld()   | old           | 保留首次写入的值，忽略后续更新 |
+
+`aggregateType(AggregateType type)` 可以直接设置该项，传入 `AggregateType.NONE` 即恢复默认。
+
+- writeType：属性属于 OLTP 图数据还是 OLAP 计算结果，对于 OLAP 还区分是否带索引，默认为 oltp；
+
+| writeType      | description            |
+|----------------|------------------------|
+| OLTP           | 普通图属性              |
+| OLAP_COMMON    | 不带索引的 OLAP 属性     |
+| OLAP_SECONDARY | 带二级索引的 OLAP 属性   |
+| OLAP_RANGE     | 带范围索引的 OLAP 属性   |
+
+| interface                        | description            |
+|----------------------------------|------------------------|
+| writeType(WriteType writeType)   | 使用枚举值设置写入类型  |
+| writeType(String name)           | 使用枚举名设置写入类型  |
 
 - userdata：用户可以自己添加一些约束或额外信息，然后自行检查传入的属性是否满足约束，或者必要的时候提取出额外信息
 
@@ -133,7 +203,7 @@ schema.getPropertyKey("name").userdata()
 
 VertexLabel 用来定义顶点类型，描述顶点的约束信息：
 
-VertexLabel 允许定义的约束信息包括：name、idStrategy、properties、primaryKeys 和 nullableKeys，下面逐一介绍。
+VertexLabel 允许定义的约束信息包括：name、idStrategy、properties、primaryKeys、nullableKeys 和 ttl，下面逐一介绍。
 
 - name: 属性的名字，用来区分不同的 VertexLabel，不允许有同名的属性；
 
@@ -148,6 +218,7 @@ VertexLabel 允许定义的约束信息包括：name、idStrategy、properties�
 | useAutomaticId       | AUTOMATIC        | generate id automatically by Snowflake algorithm        |
 | useCustomizeStringId | CUSTOMIZE_STRING | passed id by user, must be string type                  |
 | useCustomizeNumberId | CUSTOMIZE_NUMBER | passed id by user, must be number type                  |
+| useCustomizeUuidId   | CUSTOMIZE_UUID   | passed id by user, must be UUID type                    |
 | usePrimaryKeyId      | PRIMARY_KEY      | choose some important prop as primary key to splice id  |
 
 - properties: 定义顶点的属性，传入的参数是 PropertyKey 的 name
@@ -169,6 +240,8 @@ VertexLabel 允许定义的约束信息包括：name、idStrategy、properties�
 | unset primaryKeys | AUTOMATIC      | CUSTOMIZE_STRING     | CUSTOMIZE_NUMBER     | ERROR           |
 | set primaryKeys   | ERROR          | ERROR                | ERROR                | PRIMARY_KEY     |
 
+客户端自身只校验 Id 策略是否被重复设置，因此在同一个构造器上调用两个上述方法会在本地报错。上表中的组合由服务端校验。
+
 - nullableKeys: 对于通过 properties(...) 方法设置过的属性，默认全都是不可为空的，也就是在创建顶点时该属性必须赋值，这样可能对用户数据提出了太过严格的完整性要求。为避免这样的强约束，用户可以通过
 本方法设置若干属性为可空的，这样添加顶点时该属性可以不赋值。
 
@@ -177,6 +250,13 @@ VertexLabel 允许定义的约束信息包括：name、idStrategy、properties�
 | nullableKeys(String... properties) | allow to pass multi props |
 
 注意：primaryKeys 和 nullableKeys 不能有交集，因为一个属性不能既作为主属性，又是可空的。
+
+- ttl：该类型顶点的存活时间，默认为 0，即永不过期。客户端会拒绝负值。默认从顶点写入的时刻开始计时；设置 ttlStartTime 后，改为从该 label 的某个日期属性开始计时。
+
+| interface                        | description                     |
+|----------------------------------|---------------------------------|
+| ttl(long ttl)                    | 设置存活时间，0 表示不过期       |
+| ttlStartTime(String property)    | 指定计时起点所用的日期属性       |
 
 - enableLabelIndex：用户可以指定是否需要为 label 创建索引。不创建则无法全局搜索指定 label 的顶点和边，创建则可以全局搜索，做类似于`g.V().hasLabel('person'), g.E().has('label', 'person')`这样的查询，
 但是插入数据时性能上会更加慢，并且需要占用更多的存储空间。此项默认为 true。
@@ -202,6 +282,8 @@ schema.vertexLabel("person").useAutomaticId().properties("name", "age").ifNotExi
 schema.vertexLabel("person").useCustomizeStringId().properties("name", "age").ifNotExist().create();
 // 使用 Customize_Number 的 Id 策略
 schema.vertexLabel("person").useCustomizeNumberId().properties("name", "age").ifNotExist().create();
+// 使用 Customize_Uuid 的 Id 策略
+schema.vertexLabel("person").useCustomizeUuidId().properties("name", "age").ifNotExist().create();
 
 // 使用 PrimaryKey 的 Id 策略
 schema.vertexLabel("person").properties("name", "age").primaryKeys("name").ifNotExist().create();
@@ -235,6 +317,8 @@ schema.getVertexLabel("person").name()
 schema.getVertexLabel("person").properties()
 schema.getVertexLabel("person").nullableKeys()
 schema.getVertexLabel("person").userdata()
+schema.getVertexLabel("person").ttl()
+schema.getVertexLabel("person").ttlStartTime()
 ```
 
 #### 2.4 EdgeLabel
@@ -243,7 +327,7 @@ schema.getVertexLabel("person").userdata()
 
 EdgeLabel 用来定义边类型，描述边的约束信息。
 
-EdgeLabel 允许定义的约束信息包括：name、sourceLabel、targetLabel、frequency、properties、sortKeys 和 nullableKeys，下面逐一介绍。
+EdgeLabel 允许定义的约束信息包括：name、sourceLabel、targetLabel、frequency、properties、sortKeys、nullableKeys 和 ttl，下面逐一介绍。
 
 - name: 属性的名字，用来区分不同的 EdgeLabel，不允许有同名的属性；
 
@@ -251,14 +335,15 @@ EdgeLabel 允许定义的约束信息包括：name、sourceLabel、targetLabel�
 |------------------------|-------|----------|
 | edgeLabel(String name) | name  | y        |
 
-- sourceLabel: 边连接的源顶点类型名，只允许设置一个；
+- sourceLabel 和 targetLabel: 边连接的源顶点类型名和目标顶点类型名，两者都设置等同于声明一组连接。
 
-- targetLabel: 边连接的目标顶点类型名，只允许设置一个；
+- link: EdgeLabel 内部保存的是一组源顶点和目标顶点的组合，因此 `link(...)` 可以多次调用，让同一种边连接多组顶点类型。一旦通过这种方式添加过组合，`sourceLabel(...)` 和 `targetLabel(...)` 就会被拒绝；同时 `sourceLabel()` 和 `targetLabel()` 这两个取值方法只在恰好有一组组合时可用，需要读取全部组合时请使用 `links()`。
 
-| interface                 | param | must set |
-|---------------------------|-------|----------|
-| sourceLabel(String label) | label | y        |
-| targetLabel(String label) | label | y        |
+| interface                                    | param                    | must set                |
+|----------------------------------------------|--------------------------|-------------------------|
+| link(String sourceLabel, String targetLabel) | sourceLabel, targetLabel | y，或设置下面两项        |
+| sourceLabel(String label)                    | label                    | y，除非已使用 link()     |
+| targetLabel(String label)                    | label                    | y，除非已使用 link()     |
 
 - frequency: 字面意思是频率，表示在两个具体的顶点间某个关系出现的次数，可以是单次（single）或多次（frequency），默认为 single；
 
@@ -282,6 +367,16 @@ EdgeLabel 允许定义的约束信息包括：name、sourceLabel、targetLabel�
 - nullableKeys: 与顶点中的 nullableKeys 概念一致，不再赘述
 
 注意：sortKeys 和 nullableKeys 也不能有交集。
+
+- ttl：与顶点中的 ttl 概念一致，同样提供 `ttl(long ttl)` 和 `ttlStartTime(String property)` 方法，默认值同样为 0。
+
+- edge label type：EdgeLabel 默认为普通类型，也可以声明为一族边类型的父类型、某个父类型的子类型，或者通用类型：
+
+| interface                     | edgeLabelType | description                    |
+|-------------------------------|---------------|--------------------------------|
+| asBase()                      | PARENT        | 将该 label 声明为父类型         |
+| withBase(String parentLabel)  | SUB           | 将该 label 声明为 parentLabel 的子类型 |
+| asGeneral()                   | GENERAL       | 将该 label 声明为通用类型       |
 
 - enableLabelIndex：与顶点中的 enableLabelIndex 概念一致，不再赘述
 
@@ -325,6 +420,11 @@ schema.getEdgeLabel("knows").name()
 schema.getEdgeLabel("knows").properties()
 schema.getEdgeLabel("knows").nullableKeys()
 schema.getEdgeLabel("knows").userdata()
+schema.getEdgeLabel("knows").ttl()
+schema.getEdgeLabel("knows").ttlStartTime()
+schema.getEdgeLabel("knows").edgeLabelType()
+// 全部的源顶点和目标顶点组合，存在多组时也可安全调用
+schema.getEdgeLabel("knows").links()
 ```
 
 #### 2.5 IndexLabel
@@ -428,15 +528,15 @@ schema.getIndexLabel("personByAge").name()
 顶点是构成图的最基本元素，一个图中可以有非常多的顶点。下面给出一个添加顶点的例子：
 
 ```java
-Vertex marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29);
-Vertex lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
+Vertex marko = graph.addVertex(T.LABEL, "person", "name", "marko", "age", 29);
+Vertex lop = graph.addVertex(T.LABEL, "software", "name", "lop", "lang", "java", "price", 328);
 ```
 
 - 添加顶点的关键是顶点属性，添加顶点函数的参数个数必须为偶数，且满足`key1 -> val1, key2 -> val2 ···`的顺序排列，键值对之间的顺序是自由的。
-- 参数中必须包含一对特殊的键值对，就是`T.label -> "val"`，用来定义该顶点的类别，以便于程序从缓存或后端获取到该 VertexLabel 的 schema 定义，然后做后续的约束检查。例子中的 label 定义为 person。
+- 参数中必须包含一对特殊的键值对，就是`T.LABEL -> "val"`，用来定义该顶点的类别，以便于程序从缓存或后端获取到该 VertexLabel 的 schema 定义，然后做后续的约束检查。例子中的 label 定义为 person。`T.LABEL` 就是常量 `"label"`，直接传入该字符串效果相同。
 - 如果顶点类型的 Id 策略为 `AUTOMATIC`，则不允许用户传入 id 键值对。
-- 如果顶点类型的 Id 策略为 `CUSTOMIZE_STRING`，则用户需要自己传入 String 类型 id 的值，键值对形如：`"T.id", "123456"`。
-- 如果顶点类型的 Id 策略为 `CUSTOMIZE_NUMBER`，则用户需要自己传入 Number 类型 id 的值，键值对形如：`"T.id", 123456`。
+- 如果顶点类型的 Id 策略为 `CUSTOMIZE_STRING`，则用户需要自己传入 String 类型 id 的值，键值对形如：`T.ID, "123456"`。
+- 如果顶点类型的 Id 策略为 `CUSTOMIZE_NUMBER`，则用户需要自己传入 Number 类型 id 的值，键值对形如：`T.ID, 123456`。
 - 如果顶点类型的 Id 策略为 `PRIMARY_KEY`，参数还必须全部包含该`primaryKeys`对应属性的名和值，如果不设置会抛出异常。比如之前`person`的`primaryKeys`是`name`，例子中就设置了`name`的值为`marko`。
 - 对于非 nullableKeys 的属性，必须要赋值。
 - 剩下的参数就是顶点其他属性的设置，但并非必须。
@@ -458,6 +558,8 @@ Edge knows1 = marko.addEdge("knows", vadas, "city", "Beijing");
 
 ### 4 图管理
 Client 支持管理一个物理部署中的多个 GraphSpace，每个 GraphSpace 可以包含多个图。不指定 GraphSpace 时使用 `DEFAULT`。
+
+GraphSpace 需要服务端 core 版本不低于 1.7.0。连接更早的服务端时，客户端会退回到 legacy 模式，此时 `hugeClient.supportsGraphSpace()` 返回 false。
 
 #### 4.1 创建GraphSpace
 
@@ -486,10 +588,17 @@ spaceManager.createGraphSpace(graphSpace);
 | | updateGraphSpace(GraphSpace) | 更新配置 |
 | | setDefault(String name) | 设置默认 GraphSpace |
 | Manager - 删除 | deleteGraphSpace(String name) | 删除指定 GraphSpace |
-| GraphSpace - 属性 | getName() / getDescription() | 获取名称/描述 |
-| | getGraphNumber() | 获取图数量 |
-| GraphSpace - 配置 | setDescription(String) | 设置描述 |
-| | setMaxGraphNumber(int) | 设置最大图数量 |
+| Manager - 默认角色 | setDefaultRole(String name, String user, String role) | 授予默认角色，可用第四个参数限定到某个图 |
+| | checkDefaultRole(String name, String user, String role) | 检查默认角色，可用第四个参数限定到某个图 |
+| | deleteDefaultRole(String name, String user, String role) | 撤销默认角色，可用第四个参数限定到某个图 |
+| GraphSpace - 属性 | getName() / getNickname() / getDescription() | 获取名称/昵称/描述 |
+| | getGraphNumberUsed() / getRoleNumberUsed() | 获取已使用的图数量/角色数量 |
+| | getCpuUsed() / getMemoryUsed() / getStorageUsed() | 获取已使用的资源 |
+| | getCreateTime() / getUpdateTime() | 获取创建时间/更新时间 |
+| GraphSpace - 配置 | setDescription(String) / setNickname(String) | 设置描述/昵称 |
+| | setMaxGraphNumber(int) / setMaxRoleNumber(int) | 设置最大图数量/角色数量 |
+| | setCpuLimit(int) / setMemoryLimit(int) / setStorageLimit(int) | 设置资源配额 |
+| | setConfigs(Map&lt;String, Object&gt;) | 设置额外的配置项 |
 
 
 ### 5 简单示例

--- a/content/en/docs/clients/hugegraph-client.md
+++ b/content/en/docs/clients/hugegraph-client.md
@@ -28,6 +28,51 @@ If the above process of creating HugeClient fails, an exception will be thrown, 
 
 When operating through `gremlin` in `HugeGraph-Hubble`(or `HugeGraph-Studio`), `HugeClient` is not required and can be ignored.
 
+#### 1.1 Builder options
+
+The builder accepts the following options. Every timeout is expressed in seconds and converted to milliseconds internally.
+
+| interface                                                    | description                                                                             | default             |
+|--------------------------------------------------------------|-----------------------------------------------------------------------------------------|---------------------|
+| `configUrl(String url)`                                       | Server address, normally passed to `builder(...)` already                               | required            |
+| `configGraph(String graph)`                                   | Graph name, normally passed to `builder(...)` already                                   | required            |
+| `configGraphSpace(String graphSpace)`                         | GraphSpace name, a null or empty value falls back to `DEFAULT`                          | `DEFAULT`           |
+| `configUser(String username, String password)`                | Credentials for the server, a null value is stored as an empty string                   | empty, no auth      |
+| `configToken(String token)`                                   | Token used instead of username and password                                             | empty               |
+| `configTimeout(int seconds)`                                  | Request timeout, passing `0` restores the default                                       | 20                  |
+| `configConnectTimeout(Integer seconds)`                       | Connect timeout, left unset so that `configTimeout` applies                             | unset               |
+| `configReadTimeout(Integer seconds)`                          | Read timeout, left unset so that `configTimeout` applies                                | unset               |
+| `configPool(int maxConns, int maxConnsPerRoute)`              | Connection pool sizes, passing `0` for either one restores its default                  | 4 x CPUs, 2 x CPUs  |
+| `configIdleTime(int seconds)`                                 | Idle connection keep-alive, must be greater than 0                                      | 30                  |
+| `configSSL(String trustStoreFile, String trustStorePassword)` | Truststore used for HTTPS connections                                                   | empty               |
+| `configHttpBuilder(Consumer<OkHttpClient.Builder> consumer)`  | Callback that receives the underlying OkHttp builder for further customization          | none                |
+| `graphRequired(boolean graphRequired)`                        | Whether `build()` rejects an empty url or graph name                                    | true                |
+
+On `build()`, the client reads the server API version and rejects anything outside the range `[0.38, 0.81)`.
+
+#### 1.2 Operation entries
+
+Besides schema, graph and gremlin, HugeClient exposes the following entries. The graph-scoped ones are only available when a graph name was supplied; when the client is built with an empty graph name they return null until `assignGraph(graphSpace, graph)` is called.
+
+| interface             | returns                | scope      | description                                                                     |
+|-----------------------|------------------------|------------|---------------------------------------------------------------------------------|
+| `schema()`            | `SchemaManager`        | graph      | Manage PropertyKey, VertexLabel, EdgeLabel and IndexLabel                       |
+| `graph()`             | `GraphManager`         | graph      | Add, query, update and delete vertices and edges, single or batch               |
+| `gremlin()`           | `GremlinManager`       | graph      | Run Gremlin statements, synchronously or as an async task                       |
+| `cypher()`            | `CypherManager`        | graph      | Run Cypher statements, synchronously or as an async task                        |
+| `traverser()`         | `TraverserManager`     | graph      | RESTful traversals such as shortest path, k-out, k-neighbor and crosspoints     |
+| `variables()`         | `VariablesManager`     | graph      | Get, set, list and remove graph variables                                       |
+| `job()`               | `JobManager`           | graph      | Rebuild the index of a VertexLabel, EdgeLabel or IndexLabel                     |
+| `task()`              | `TaskManager`          | graph      | List, get, cancel, delete and wait on async tasks                               |
+| `computer()`          | `ComputerManager`      | graph      | Create, cancel, list and get computer jobs                                      |
+| `graphs()`            | `GraphsManager`        | graphspace | Create, clone, list, reload, clear and drop graphs, read and set the graph mode |
+| `graphSpace()`        | `GraphSpaceManager`    | server     | Manage GraphSpaces, see section 4                                               |
+| `auth()`              | `AuthManager`          | server     | Manage users, groups, targets, belongs and accesses                             |
+| `metrics()`           | `MetricsManager`       | server     | Read backend, system and statistics metrics                                     |
+| `versionManager()`    | `VersionManager`       | server     | Read the core, gremlin and API versions of the server                           |
+
+The client also reports what the connected server supports, so callers can branch on a capability instead of on a version string: `supportsGraphSpace()`, `supportsCypher()`, `supportsGraphCreate()`, `supportsDefaultRole()` and `isServerAuthEnabled()`.
+
 ### 2 Schema
 
 #### 2.1 SchemaManager
@@ -54,7 +99,7 @@ The definition process of the 4 kinds of schema is described below.
 
 PropertyKey is used to standardize the property constraints of vertices and edges, and properties of properties are not currently supported.
 
-The constraint information that PropertyKey allows to define includes: name, datatype, cardinality, and userdata, which are introduced one by one below.
+The constraint information that PropertyKey allows to define includes: name, datatype, cardinality, aggregateType, writeType and userdata, which are introduced one by one below.
 
 - name: The name of the property, used to distinguish different PropertyKeys, PropertyKeys with the same name are not allowed.
 
@@ -69,7 +114,7 @@ The constraint information that PropertyKey allows to define includes: name, dat
 | asText()    | String     |
 | asInt()     | Integer    |
 | asDate()    | Date       |
-| asUuid()    | UUID       |
+| asUUID()    | UUID       |
 | asBoolean() | Boolean    |
 | asByte()    | Byte       |
 | asBlob()    | Byte[]     |
@@ -84,6 +129,31 @@ The constraint information that PropertyKey allows to define includes: name, dat
 | valueSingle() | single      | single value                                |
 | valueList()   | list        | multi-values that allow duplicate value     |
 | valueSet()    | set         | multi-values that not allow duplicate value |
+
+- aggregateType: How repeated writes of the same property are combined. The default is none, which keeps the last written value. The numeric options require a number datatype:
+
+| interface   | aggregateType | description                                     |
+|-------------|---------------|-------------------------------------------------|
+| calcSum()   | sum           | accumulate the written values                   |
+| calcMax()   | max           | keep the greatest value                         |
+| calcMin()   | min           | keep the smallest value                         |
+| calcOld()   | old           | keep the first written value and ignore updates |
+
+`aggregateType(AggregateType type)` sets the same thing directly, and `AggregateType.NONE` restores the default.
+
+- writeType: Whether the property belongs to the OLTP graph or to an OLAP computing result, and for OLAP whether it carries an index. The default is oltp:
+
+| writeType      | description                          |
+|----------------|--------------------------------------|
+| OLTP           | ordinary graph property              |
+| OLAP_COMMON    | OLAP property without index          |
+| OLAP_SECONDARY | OLAP property with a secondary index |
+| OLAP_RANGE     | OLAP property with a range index     |
+
+| interface                        | description                            |
+|----------------------------------|----------------------------------------|
+| writeType(WriteType writeType)   | set the write type with the enum value |
+| writeType(String name)           | set the write type by enum name        |
 
 - userdata: Users can add some constraints or additional information by themselves, and then check whether the incoming properties satisfy the constraints, or extract additional information when necessary:
 
@@ -132,7 +202,7 @@ schema.getPropertyKey("name").userdata()
 
 VertexLabel is used to define the vertex type and describe the constraint information of the vertex.
 
-The constraint information that VertexLabel allows to define include: name, idStrategy, properties, primaryKeys and nullableKeys, which are introduced one by one below.
+The constraint information that VertexLabel allows to define include: name, idStrategy, properties, primaryKeys, nullableKeys and ttl, which are introduced one by one below.
 
 - name: The name of the VertexLabel, used to distinguish different VertexLabels, VertexLabels with the same name are not allowed.
 
@@ -147,6 +217,7 @@ The constraint information that VertexLabel allows to define include: name, idSt
 | useAutomaticId       | AUTOMATIC        | generate id automatically by Snowflake algorithm        |
 | useCustomizeStringId | CUSTOMIZE_STRING | passed id by user, must be string type                  |
 | useCustomizeNumberId | CUSTOMIZE_NUMBER | passed id by user, must be number type                  |
+| useCustomizeUuidId   | CUSTOMIZE_UUID   | passed id by user, must be UUID type                    |
 | usePrimaryKeyId      | PRIMARY_KEY      | choose some important prop as primary key to splice id  |
 
 - properties: define the properties of the vertex, the incoming parameter is the name of the PropertyKey.
@@ -168,6 +239,8 @@ Note that the selection of the ID strategy and the setting of primaryKeys have s
 | unset primaryKeys | AUTOMATIC      | CUSTOMIZE_STRING     | CUSTOMIZE_NUMBER     | ERROR           |
 | set primaryKeys   | ERROR          | ERROR                | ERROR                | PRIMARY_KEY     |
 
+The client itself only checks that the ID strategy is set once, so calling two of these methods on the same builder fails locally. The combinations above are validated by the server.
+
 - nullableKeys: For properties set by the properties(...) method, all of them are non-nullable by default, that is, the property must be assigned a value when creating a vertex, which may impose too strict integrity requirements on user data. In order to avoid such strong constraints, the user can set some properties to be nullable through this method, so that the properties can be unassigned when adding vertices.
 
 | interface                          | description               |
@@ -175,6 +248,13 @@ Note that the selection of the ID strategy and the setting of primaryKeys have s
 | nullableKeys(String... properties) | allow to pass multi props |
 
 Note: primaryKeys and nullableKeys cannot intersect, because a property cannot be both primary and nullable.
+
+- ttl: Time to live of the vertices of this label. The default is 0, which means they never expire. The client rejects a negative value. By default the countdown is relative to the moment the vertex is written; ttlStartTime instead names a date property of the label that the countdown is measured from.
+
+| interface                        | description                                         |
+|----------------------------------|-----------------------------------------------------|
+| ttl(long ttl)                    | set the time to live, 0 disables expiry             |
+| ttlStartTime(String property)    | name the date property the countdown starts from    |
 
 - enableLabelIndex: The user can specify whether to create an index for the label. If you don't create it, you can't globally search for the vertices and edges of the specified label. If you create it, you can search globally, like `g.V().hasLabel('person'), g.E().has('label', 'person')` query, but the performance will be slower when inserting data, and it will take up more storage space. This defaults to true.
 
@@ -199,6 +279,8 @@ schema.vertexLabel("person").useAutomaticId().properties("name", "age").ifNotExi
 schema.vertexLabel("person").useCustomizeStringId().properties("name", "age").ifNotExist().create();
 // Use Customize_Number Id strategy
 schema.vertexLabel("person").useCustomizeNumberId().properties("name", "age").ifNotExist().create();
+// Use Customize_Uuid Id strategy
+schema.vertexLabel("person").useCustomizeUuidId().properties("name", "age").ifNotExist().create();
 
 // Use PrimaryKey Id strategy
 schema.vertexLabel("person").properties("name", "age").primaryKeys("name").ifNotExist().create();
@@ -232,6 +314,8 @@ schema.getVertexLabel("person").name()
 schema.getVertexLabel("person").properties()
 schema.getVertexLabel("person").nullableKeys()
 schema.getVertexLabel("person").userdata()
+schema.getVertexLabel("person").ttl()
+schema.getVertexLabel("person").ttlStartTime()
 ```
 
 #### 2.4 EdgeLabel
@@ -240,7 +324,7 @@ schema.getVertexLabel("person").userdata()
 
 EdgeLabel is used to define the edge type and describe the constraint information of the edge.
 
-The constraint information that EdgeLabel allows to define include: name, sourceLabel, targetLabel, frequency, properties, sortKeys and nullableKeys, which are introduced one by one below.
+The constraint information that EdgeLabel allows to define include: name, sourceLabel, targetLabel, frequency, properties, sortKeys, nullableKeys and ttl, which are introduced one by one below.
 
 - name: The name of the EdgeLabel, used to distinguish different EdgeLabels, EdgeLabels with the same name are not allowed.
 
@@ -248,14 +332,15 @@ The constraint information that EdgeLabel allows to define include: name, source
 |------------------------|-------|----------|
 | edgeLabel(String name) | name  | y        |
 
-- sourceLabel: The name of the source vertex type of the edge link, only one is allowed;
+- sourceLabel and targetLabel: The names of the source and the target vertex type of the edge link. Setting both is the same as declaring one link pair.
 
-- targetLabel: The name of the target vertex type of the edge link, only one is allowed;
+- link: An EdgeLabel holds a set of source and target pairs, so `link(...)` can be called more than once to let the same edge type connect several pairs of vertex types. Once a pair has been added this way, `sourceLabel(...)` and `targetLabel(...)` are rejected, and the `sourceLabel()` and `targetLabel()` getters only work on a label that has exactly one pair. Use `links()` to read them all.
 
-| interface                 | param | must set |
-|---------------------------|-------|----------|
-| sourceLabel(String label) | label | y        |
-| targetLabel(String label) | label | y        |
+| interface                                    | param                    | must set                  |
+|----------------------------------------------|--------------------------|---------------------------|
+| link(String sourceLabel, String targetLabel) | sourceLabel, targetLabel | y, or set the two below   |
+| sourceLabel(String label)                    | label                    | y, unless link() was used |
+| targetLabel(String label)                    | label                    | y, unless link() was used |
 
 - frequency: Indicating the number of times a relationship occurs between two specific vertices, which can be single (single) or multiple (frequency), the default is single.
 
@@ -279,6 +364,16 @@ The constraint information that EdgeLabel allows to define include: name, source
 - nullableKeys: Consistent with the concept of nullableKeys in vertices.
 
 Note: sortKeys and nullableKeys also cannot intersect.
+
+- ttl: Consistent with the concept of ttl in vertices, with the same `ttl(long ttl)` and `ttlStartTime(String property)` methods and the same default of 0.
+
+- edge label type: An EdgeLabel is normal by default. It can instead be declared as the parent of a family of edge labels, as a child of such a parent, or as a general label:
+
+| interface                     | edgeLabelType | description                                    |
+|-------------------------------|---------------|------------------------------------------------|
+| asBase()                      | PARENT        | declare the label as a parent label            |
+| withBase(String parentLabel)  | SUB           | declare the label as a child of 'parentLabel'  |
+| asGeneral()                   | GENERAL       | declare the label as a general label           |
 
 - enableLabelIndex: It is consistent with the concept of enableLabelIndex in the vertex.
 
@@ -322,6 +417,11 @@ schema.getEdgeLabel("knows").name()
 schema.getEdgeLabel("knows").properties()
 schema.getEdgeLabel("knows").nullableKeys()
 schema.getEdgeLabel("knows").userdata()
+schema.getEdgeLabel("knows").ttl()
+schema.getEdgeLabel("knows").ttlStartTime()
+schema.getEdgeLabel("knows").edgeLabelType()
+// All the source and target pairs, safe to call when there is more than one
+schema.getEdgeLabel("knows").links()
 ```
 
 #### 2.5 IndexLabel
@@ -416,15 +516,15 @@ schema.getIndexLabel("personByAge").name()
 Vertices are the most basic elements of a graph, and there can be many vertices in a graph. Here is an example of adding vertices:
 
 ```java
-Vertex marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29);
-Vertex lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
+Vertex marko = graph.addVertex(T.LABEL, "person", "name", "marko", "age", 29);
+Vertex lop = graph.addVertex(T.LABEL, "software", "name", "lop", "lang", "java", "price", 328);
 ```
 
 - The key to adding vertices is the vertex properties. The number of parameters of the vertex adding function must be an even number and satisfy the order of `key1 -> val1, key2 -> val2 ...`, and the order between key-value pairs is free .
-- The parameter must contain a special key-value pair, namely `T.label -> "val"`, which is used to define the category of the vertex, so that the program can obtain the schema definition of the VertexLabel from the cache or backend, and then do subsequent constraint checks. The label in the example is defined as person.
+- The parameter must contain a special key-value pair, namely `T.LABEL -> "val"`, which is used to define the category of the vertex, so that the program can obtain the schema definition of the VertexLabel from the cache or backend, and then do subsequent constraint checks. The label in the example is defined as person. `T.LABEL` is the constant `"label"`, so the plain string works just as well.
 - If the vertex type's ID policy is `AUTOMATIC`, users are not allowed to pass in id key-value pairs.
-- If the ID policy of the vertex type is `CUSTOMIZE_STRING`, the user needs to pass in the value of the id of the String type. The key-value pair is like: `"T.id", "123456"`.
-- If the ID policy of the vertex type is `CUSTOMIZE_NUMBER`, the user needs to pass in the value of the id of the Number type. The key-value pair is like: `"T.id", 123456`.
+- If the ID policy of the vertex type is `CUSTOMIZE_STRING`, the user needs to pass in the value of the id of the String type. The key-value pair is like: `T.ID, "123456"`.
+- If the ID policy of the vertex type is `CUSTOMIZE_NUMBER`, the user needs to pass in the value of the id of the Number type. The key-value pair is like: `T.ID, 123456`.
 - If the ID policy of the vertex type is `PRIMARY_KEY`, the parameters must also contain the name and value of the properties corresponding to the `primaryKeys`, if not set an exception will be thrown. For example, the `primaryKeys` of `person` is `name`, in the example, the value of `name` is set to `marko`.
 - For properties that are not nullableKeys, a value must be assigned.
 - The remaining parameters are the settings of other properties of the vertex, but they are not required.
@@ -447,6 +547,8 @@ Edge knows1 = marko.addEdge("knows", vadas, "city", "Beijing");
 
 ### 4 GraphSpace
 The client can manage multiple GraphSpaces in one physical deployment, and each GraphSpace can contain multiple graphs. When no GraphSpace is specified, it uses `DEFAULT`.
+
+GraphSpaces need a server of core version 1.7.0 or later. Against an older server the client falls back to a legacy profile, and `hugeClient.supportsGraphSpace()` returns false.
 
 #### 4.1 Create GraphSpace
 
@@ -476,10 +578,17 @@ spaceManager.createGraphSpace(graphSpace);
 |           | updateGraphSpace(GraphSpace) | Update configuration |
 |           | setDefault(String name) | Set the default GraphSpace |
 | Manager - Delete | deleteGraphSpace(String name) | Delete the specified GraphSpace |
-| GraphSpace - Properties | getName() / getDescription() | Get name / description |
-|           | getGraphNumber() | Get the number of graphs |
-| GraphSpace - Configuration | setDescription(String) | Set description |
-|           | setMaxGraphNumber(int) | Set the maximum number of graphs |
+| Manager - Default role | setDefaultRole(String name, String user, String role) | Grant a default role, optionally scoped to a graph with a fourth argument |
+|           | checkDefaultRole(String name, String user, String role) | Check a default role, optionally scoped to a graph with a fourth argument |
+|           | deleteDefaultRole(String name, String user, String role) | Revoke a default role, optionally scoped to a graph with a fourth argument |
+| GraphSpace - Properties | getName() / getNickname() / getDescription() | Get name / nickname / description |
+|           | getGraphNumberUsed() / getRoleNumberUsed() | Get the number of graphs / roles in use |
+|           | getCpuUsed() / getMemoryUsed() / getStorageUsed() | Get the resources in use |
+|           | getCreateTime() / getUpdateTime() | Get the creation / update time |
+| GraphSpace - Configuration | setDescription(String) / setNickname(String) | Set description / nickname |
+|           | setMaxGraphNumber(int) / setMaxRoleNumber(int) | Set the maximum number of graphs / roles |
+|           | setCpuLimit(int) / setMemoryLimit(int) / setStorageLimit(int) | Set the resource quotas |
+|           | setConfigs(Map&lt;String, Object&gt;) | Set extra configuration entries |
 
 ### 5 Simple Example
 


### PR DESCRIPTION
## Purpose of the PR

Sync the hugegraph-client docs (en + cn) with hugegraph-toolchain master (3b385c3d).

The client pages had three API names that do not exist on master, and were missing most of the builder surface plus several schema features. The quickstart pages (`content/{en,cn}/docs/quickstart/client/hugegraph-client.md`) were checked against master too and needed no change: the Maven version 1.7.0 is still the latest release (master's `revision` 1.8.0 is unreleased), the JDK 11 / Java 8 target note matches `.github/workflows/client-ci.yml:31` and `pom.xml:112`, and both examples still match `hugegraph-client/src/main/java/org/apache/hugegraph/example/`.

| Page | What was wrong | What changed | Source on master |
|------|----------------|--------------|------------------|
| content/{en,cn}/docs/clients/hugegraph-client.md | Datatype table listed `asUuid()`, which does not exist and would not compile | Renamed to `asUUID()` | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/PropertyKey.java:101 |
| content/{en,cn}/docs/clients/hugegraph-client.md | Vertex examples used `T.label`; the id bullets used the literal string `"T.id"`, which never matches the lookup key | Changed to `T.LABEL` and `T.ID`, and noted that `T.LABEL` is the constant `"label"` | hugegraph-client/src/main/java/org/apache/hugegraph/structure/constant/T.java:22, GraphManager.java:72 |
| content/{en,cn}/docs/clients/hugegraph-client.md | GraphSpace table listed `getGraphNumber()`, which does not exist | Renamed to `getGraphNumberUsed()`, and added the other property and quota accessors | hugegraph-client/src/main/java/org/apache/hugegraph/structure/space/GraphSpace.java:280 |
| content/{en,cn}/docs/clients/hugegraph-client.md | Only `configTimeout` and `configUser` were shown, the other builder options were undocumented | Added section 1.1 with every option and its default, including the pool, idle-time, SSL, token, connect/read timeout and OkHttp callback options | hugegraph-client/src/main/java/org/apache/hugegraph/driver/HugeClientBuilder.java:28, :92 |
| content/{en,cn}/docs/clients/hugegraph-client.md | Page implied schema, graph and gremlin were the only entries | Added section 1.2 listing the manager entries, which ones need a graph, and the `supports*` capability checks | hugegraph-client/src/main/java/org/apache/hugegraph/driver/HugeClient.java:158, :225 |
| content/{en,cn}/docs/clients/hugegraph-client.md | No mention of the server API version handshake | Noted that `build()` rejects a server API version outside `[0.38, 0.81)` | hugegraph-client/src/main/java/org/apache/hugegraph/driver/HugeClient.java:218 |
| content/{en,cn}/docs/clients/hugegraph-client.md | PropertyKey section omitted aggregateType | Added the `calcSum/calcMax/calcMin/calcOld` table and the `aggregateType(...)` setter, default none | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/PropertyKey.java:123, structure/constant/AggregateType.java:25 |
| content/{en,cn}/docs/clients/hugegraph-client.md | PropertyKey section omitted writeType | Added the OLTP / OLAP_COMMON / OLAP_SECONDARY / OLAP_RANGE table, default oltp | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/PropertyKey.java:125, structure/constant/WriteType.java:26 |
| content/{en,cn}/docs/clients/hugegraph-client.md | idStrategy table was missing the UUID strategy | Added `useCustomizeUuidId` / `CUSTOMIZE_UUID` to the table and to the create examples | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/VertexLabel.java:109, structure/constant/IdStrategy.java:32 |
| content/{en,cn}/docs/clients/hugegraph-client.md | VertexLabel and EdgeLabel ttl were undocumented | Added ttl and ttlStartTime for both, default 0, plus the getters in the query examples | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/VertexLabel.java:117, EdgeLabel.java:199 |
| content/{en,cn}/docs/clients/hugegraph-client.md | EdgeLabel said only one source and one target label were allowed | Documented `link(...)`, which can be called repeatedly, that `sourceLabel(...)` is rejected afterwards, and that the single-pair getters only work on a one-pair label | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/EdgeLabel.java:175, :272, :104 |
| content/{en,cn}/docs/clients/hugegraph-client.md | Edge label types were undocumented | Added the `asBase()` / `withBase(...)` / `asGeneral()` table | hugegraph-client/src/main/java/org/apache/hugegraph/structure/schema/EdgeLabel.java:177, structure/constant/EdgeLabelType.java:24 |
| content/{en,cn}/docs/clients/hugegraph-client.md | GraphSpace summary omitted the default-role methods | Added setDefaultRole, checkDefaultRole and deleteDefaultRole, noting the optional graph argument | hugegraph-client/src/main/java/org/apache/hugegraph/driver/GraphSpaceManager.java:71 |
| content/{en,cn}/docs/clients/hugegraph-client.md | No minimum server version was given for GraphSpaces | Noted that GraphSpaces need server core 1.7.0 or later, otherwise `supportsGraphSpace()` is false | hugegraph-client/src/main/java/org/apache/hugegraph/driver/ServerCompatibility.java:31 |

The primaryKeys / id-strategy constraint matrix was left as it is, since that combination is validated server side and cannot be confirmed from the toolchain repo. A sentence was added saying what the client itself checks, which is only that the id strategy is not set twice.
