### PR TITLE
doc(server): sync store with master

### DIFF
--- a/content/cn/docs/quickstart/hugegraph/hugegraph-hstore.md
+++ b/content/cn/docs/quickstart/hugegraph/hugegraph-hstore.md
@@ -13,12 +13,14 @@ search_boost: 1.5
 
 HugeGraph-Store 是 HugeGraph 分布式版本的存储节点组件，负责实际存储和管理图数据。它与 HugeGraph-PD 协同工作，共同构成 HugeGraph 的分布式存储引擎，提供高可用性和水平扩展能力。
 
+每个 Store 节点使用 RocksDB 保存图数据，并通过 Raft（JRaft）进行复制：每个分区是一个独立的 Raft 组，因此分区在丢失少数副本时仍可继续工作。Store 节点之间并不直接感知彼此，它们向 PD 注册，由 PD 下发分区分配，并通过心跳上报状态。HugeGraph-Server 先从 PD 查询分区位置，再通过 gRPC 访问 Store。
+
 ### 2 依赖
 
 #### 2.1 前置条件
 
 - 操作系统：Linux 或 macOS（Windows 尚未经过完整测试）
-- Java 版本：≥ 11
+- Java 版本：≥ 11（编译期强制校验，`bin/start-hugegraph-store.sh` 启动时会再次检查）
 - Maven 版本：≥ 3.5.0
 - 如需进行多节点部署，请先部署 HugeGraph-PD
 
@@ -37,7 +39,7 @@ HugeGraph-Store 是 HugeGraph 分布式版本的存储节点组件，负责实�
 # 1.7.0 是项目孵化期发布的历史版本，因此文件名和目录名仍带 incubating
 wget https://downloads.apache.org/hugegraph/1.7.0/apache-hugegraph-incubating-1.7.0.tar.gz
 tar zxf apache-hugegraph-incubating-1.7.0.tar.gz
-cd apache-hugegraph-incubating-1.7.0/apache-hugegraph-hstore-incubating-1.7.0
+cd apache-hugegraph-incubating-1.7.0/apache-hugegraph-store-incubating-1.7.0
 ```
 
 #### 3.2 源码编译
@@ -55,17 +57,36 @@ mvn clean install -DskipTests=true
 #    target/apache-hugegraph-{version}.tar.gz
 ```
 
+如果只想单独编译 Store 而不是整个仓库，需要先编译 `hugegraph-struct`，因为 Store 依赖它：
+
+```bash
+mvn install -pl hugegraph-struct -am -DskipTests
+mvn clean package -pl hugegraph-store/hg-store-dist -am -DskipTests
+```
+
+生成的目录只包含 `bin/`、`conf/` 和 `lib/hg-store-node-{version}.jar`。
+
 #### 3.3 Docker 部署
 
 HugeGraph-Store Docker 镜像已发布在 Docker Hub，镜像名是 `hugegraph/store`。
 
 > 注: 后续步骤皆假设你本地**已拉取** `hugegraph` 主仓库代码 (至少是 docker 目录)
 
-使用 docker-compose 文件部署完整的 3 节点集群（PD + Store + Server）：
+有两个 compose 文件包含 Store：
+
+| Compose 文件 | 拓扑 | 用途 |
+|--------------|------|------|
+| `docker-compose-hstore.yml` | 1 PD + 1 Store + 1 Server + 1 Hubble | 最小分布式部署 |
+| `docker-compose-3pd-3store-3server.yml` | 3 PD + 3 Store + 3 Server + 1 Hubble | 多节点参考部署 |
 
 ```bash
 cd hugegraph/docker
 # 注意版本号请随时保持更新 → 1.x.0
+
+# 最小分布式部署
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-hstore.yml up -d --wait
+
+# 或者多节点集群
 HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
 
@@ -86,14 +107,23 @@ docker run -d \
 
 **环境变量参考：**
 
-| 变量 | 必填 | 默认值 | 描述 |
-|------|------|--------|------|
-| `HG_STORE_PD_ADDRESS` | 是 | — | PD gRPC 地址（如 `pd0:8686,pd1:8686,pd2:8686`） |
-| `HG_STORE_GRPC_HOST` | 是 | — | 本节点的 gRPC 主机名/IP（如 `store0`） |
-| `HG_STORE_RAFT_ADDRESS` | 是 | — | 本节点的 Raft 地址（如 `store0:8510`） |
-| `HG_STORE_GRPC_PORT` | 否 | `8500` | gRPC 服务端口 |
-| `HG_STORE_REST_PORT` | 否 | `8520` | REST API 端口 |
-| `HG_STORE_DATA_PATH` | 否 | `/hugegraph-store/storage` | 数据存储路径 |
+| 变量 | 必填 | 默认值 | 对应配置项 | 描述 |
+|------|------|--------|------------|------|
+| `HG_STORE_PD_ADDRESS` | 是 | n/a | `pdserver.address` | PD gRPC 地址（如 `pd0:8686,pd1:8686,pd2:8686`） |
+| `HG_STORE_GRPC_HOST` | 是 | n/a | `grpc.host` | 本节点的 gRPC 主机名/IP（如 `store0`） |
+| `HG_STORE_RAFT_ADDRESS` | 是 | n/a | `raft.address` | 本节点的 Raft 地址（如 `store0:8510`） |
+| `HG_STORE_GRPC_PORT` | 否 | `8500` | `grpc.port` | gRPC 服务端口 |
+| `HG_STORE_REST_PORT` | 否 | `8520` | `server.port` | REST API 端口 |
+| `HG_STORE_DATA_PATH` | 否 | `/hugegraph-store/storage` | `app.data-path` | 数据存储路径 |
+
+入口脚本会把这些变量转换为 `SPRING_APPLICATION_JSON`，覆盖在 `conf/application.yml` 之上，然后执行 `bin/start-hugegraph-store.sh -d false -j "$JAVA_OPTS"`。上表未覆盖的配置项仍需要修改 `conf/application.yml`，或者自行提供 `SPRING_APPLICATION_JSON`。
+
+镜像细节：
+
+- `JAVA_OPTS` 默认值为 `-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -XshowSettings:vm`
+- `STDOUT_MODE=true`，因此 Java 日志输出到容器 stdout，而不是 `logs/hugegraph-store-server.log`
+- `HEALTHCHECK` 在 90 秒启动期后每 15 秒访问一次 `GET http://localhost:8520/v1/health`
+- 镜像只声明了 `EXPOSE 8520`；如果需要从 Docker 网络之外访问 8500 和 8510，请自行发布这两个端口
 
 > **注意**：在 Docker 桥接网络中，`HG_STORE_GRPC_HOST` 应使用容器主机名（如 `store0`）而非 IP 地址。
 
@@ -101,34 +131,49 @@ docker run -d \
 
 ### 4 配置
 
-Store 的主要配置文件为 `conf/application.yml`，以下是关键配置项：
+Store 从 `conf/` 读取两个配置文件：
+
+- `application.yml`，主配置文件（PD 地址、各端口、Raft、数据路径）
+- `application-pd.yml`，由 `application.yml` 中的 `spring.profiles.include: pd` 引入，包含 RocksDB 内存设置和 Actuator 暴露配置
+
+#### 4.1 application.yml
+
+发布包中自带的文件内容如下：
 
 ```yaml
 pdserver:
-  # PD 服务地址，多个 PD 地址用逗号分割（配置 PD 的 gRPC 端口）
-  address: 127.0.0.1:8686
+  # PD service address, multiple PD addresses separated by commas
+  address: localhost:8686
+
+management:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
 
 grpc:
-  # gRPC 的服务地址
+  # grpc service address
   host: 127.0.0.1
   port: 8500
   netty-server:
     max-inbound-message-size: 1000MB
-
 raft:
-  # raft 缓存队列大小
+  # raft cache queue size
   disruptorBufferSize: 1024
   address: 127.0.0.1:8510
   max-log-file-size: 600000000000
-  # 快照生成时间间隔，单位秒
+  # Snapshot generation interval, in seconds
   snapshotInterval: 1800
-
 server:
-  # REST 服务地址
+  # rest service address
   port: 8520
 
 app:
-  # 存储路径，支持多个路径，逗号分割
+  # Storage path, support multiple paths, separated by commas
   data-path: ./storage
   #raft-path: ./storage
 
@@ -145,12 +190,146 @@ logging:
     root: info
 ```
 
+#### 4.2 application-pd.yml
+
+```yaml
+management:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+rocksdb:
+  # rocksdb total memory usage, force flush to disk when reaching this value
+  total_memory_size: 32000000000
+  # memtable size used by rocksdb
+  write_buffer_size: 32000000
+  # For each rocksdb, the number of memtables reaches this value for writing to disk.
+  min_write_buffer_number_to_merge: 16
+```
+
+#### 4.3 配置项参考
+
+下表中「模板值」是上面两个文件中的取值，「代码默认值」是配置项缺失时节点使用的回退值；模板未列出的配置项应以代码默认值为准。
+
+**核心**
+
+| 配置项 | 模板值 | 代码默认值 | 说明 |
+|--------|--------|------------|------|
+| `pdserver.address` | `localhost:8686` | 必填 | PD gRPC 地址，多个地址用逗号分隔。Store 在此注册并获取分区分配。必须填写 PD 的 `grpc.port`，不是 PD 的 REST 端口。 |
+| `grpc.host` | `127.0.0.1` | 必填 | 本节点对外公布的 gRPC 地址。应设置为可路由的 IP 或主机名，`127.0.0.1` 只适用于单机部署。 |
+| `grpc.port` | `8500` | 必填 | gRPC 端口，Server 和 Store 客户端连接此端口。 |
+| `grpc.netty-server.max-inbound-message-size` | `1000MB` | gRPC 默认值 | 单个入站 gRPC 消息的最大大小，由 `grpc-spring-boot-starter` 的 Netty 服务端读取。 |
+| `grpc.server.wait-time` | 未设置 | `3600` | 扫描流等待客户端消费一页数据的秒数，超时后服务端中止该流。 |
+| `server.port` | `8520` | 必填 | REST 和 Actuator 端口，同时以 `rest.port` 标签上报给 PD。 |
+
+**Raft**
+
+| 配置项 | 模板值 | 代码默认值 | 说明 |
+|--------|--------|------------|------|
+| `raft.address` | `127.0.0.1:8510` | 必填 | 本节点的 Raft 服务地址，格式为 `host:port`，必须能被其他 Store 节点访问。这里不需要配置 peer 列表：分区 Raft 组的成员由 PD 下发。 |
+| `raft.disruptorBufferSize` | `1024` | `0` | Raft 任务队列大小。设为 `0` 时按 `rocksdb.total_memory_size` 推导：将该内存量的 GB 数取最接近的 2 的幂，再乘以 32。 |
+| `raft.max-log-file-size` | `600000000000` | `50000000000` | Raft 日志的最大字节数。 |
+| `raft.snapshotInterval` | `1800` | `300` | 生成 Raft 快照的时间间隔，单位秒。 |
+| `raft.snapshotLogIndexMargin` | 未设置 | `0` | 距上次快照的最小 applied index 差值，达到后才真正生成快照。设为 `0` 关闭该判断。 |
+| `raft.rpc-timeout` | 未设置 | `10000` | Raft RPC 超时时间，单位毫秒。 |
+| `raft.metrics` | 未设置 | `true` | 采集 JRaft 节点指标，可通过 `/metrics/raft` 读取。 |
+| `raft.useRocksDBSegmentLogStorage` | 未设置 | `true` | 使用 RocksDB 分段日志存储保存 Raft 日志。 |
+| `raft.maxSegmentFileSize` | 未设置 | `67108864` | 分段日志文件大小，单位字节（64 MB）。 |
+| `raft.maxReplicatorInflightMsgs` | 未设置 | `256` | 每个 follower 的最大在途复制请求数。 |
+| `raft.maxEntriesSize` | 未设置 | `256` | 单次 `AppendEntries` 请求包含的最大条目数。 |
+| `raft.maxBodySize` | 未设置 | `524288` | 单次 `AppendEntries` 请求的最大字节数。 |
+| `ave-logEntry-size-ratio` | 未设置 | `0.95` | 估算日志条目平均大小时的平滑系数。注意该配置项位于顶层，不在 `raft` 下。 |
+
+**存储与标签**
+
+| 配置项 | 模板值 | 代码默认值 | 说明 |
+|--------|--------|------------|------|
+| `app.data-path` | `./storage` | `store` | RocksDB 数据目录。用逗号分隔多个路径可将分区分散到多块磁盘。 |
+| `app.raft-path` | 已注释 | 空 | Raft 日志和快照目录。为空时回退到 `app.data-path`。 |
+| `app.fake-pd` | 未设置 | `false` | 内置 PD 模式，仅用于单机测试，不要用于生产。 |
+| `app.placeholder-size` | 未设置 | `10` | 启动时在每个数据路径下创建的 `placeholder` 占位文件大小，单位 GB，便于紧急情况下释放空间。设为 `0` 关闭。 |
+| `app.label.<name>` | 未设置 | 无 | 随 store 心跳上报给 PD 的自定义键值标签。节点会自动追加 `rest.port`。 |
+
+**RocksDB**
+
+| 配置项 | 模板值 | 代码默认值 | 说明 |
+|--------|--------|------------|------|
+| `rocksdb.total_memory_size` | `32000000000` | `51539607552` | 本节点所有 RocksDB 实例共享的内存预算。缺失或为 `0` 时使用 JVM 最大堆内存。 |
+| `rocksdb.write_buffer_size` | `32000000` | `33554432` | memtable 大小，单位字节。缺失或为 `0` 时取 `total_memory_size / 1000`。 |
+| `rocksdb.min_write_buffer_number_to_merge` | `16` | `16` | 落盘前合并的 memtable 数量。 |
+| `rocksdb.write_buffer_ratio` | 未设置 | `0.66` | `total_memory_size` 中分配给写缓存的比例，其余作为 block cache。 |
+
+`org/apache/hugegraph/rocksdb/access/RocksDBOptions.java` 中定义的其他选项都可以加在同一个 `rocksdb:` 块下，例如 `rocksdb.max_background_jobs`、`rocksdb.level0_file_num_compaction_trigger` 或 `rocksdb.bloom_filter_bits_per_key`。
+
+**线程池**
+
+| 配置项 | 代码默认值 | 说明 |
+|--------|------------|------|
+| `thread.pool.grpc.core` | `600` | 处理 gRPC 请求的核心线程数。 |
+| `thread.pool.grpc.max` | `1000` | gRPC 最大线程数。 |
+| `thread.pool.grpc.queue` | `2147483647` | gRPC 任务队列容量。 |
+| `thread.pool.scan.core` | `128` | 处理扫描的核心线程数。设为 `0` 时取 CPU 核数的 4 倍。 |
+| `thread.pool.scan.max` | `1000` | 扫描最大线程数。 |
+| `thread.pool.scan.queue` | `0` | 扫描任务队列容量。 |
+
+**查询下推**
+
+| 配置项 | 代码默认值 | 说明 |
+|--------|------------|------|
+| `query.push-down.threads` | `1500` | 下推查询的线程池大小。 |
+| `query.push-down.fetch_batch` | `20000` | 单次请求拉取的行数。 |
+| `query.push-down.fetch_timeout` | `300000` | 拉取超时时间，单位毫秒。 |
+| `query.push-down.memory_limit_count` | `50000` | 排序等内存操作的行数上限。 |
+| `query.push-down.index_size_limit_count` | `50000` | 索引 sst 文件大小上限，单位 kB。 |
+
+**后台任务**
+
+| 配置项 | 代码默认值 | 说明 |
+|--------|------------|------|
+| `job.interruptableThreadPool.core` | `128` | TTL 清理线程池的核心线程数。设为 `0` 时取 CPU 核数。 |
+| `job.interruptableThreadPool.max` | `256` | TTL 清理线程池的最大线程数。设为 `0` 时取 CPU 核数的 4 倍。 |
+| `job.interruptableThreadPool.queue` | `2147483647` | TTL 清理线程池的队列容量。 |
+| `job.uninterruptibleThreadPool.core` | `0` | 存储引擎不可中断任务线程池的核心线程数。设为 `0` 时取 CPU 核数。 |
+| `job.uninterruptibleThreadPool.max` | `256` | 不可中断任务线程池的最大线程数。 |
+| `job.uninterruptibleThreadPool.queue` | `2147483647` | 不可中断任务线程池的队列容量。 |
+| `job.cleaner.batch.size` | `10000` | TTL 清理任务每批删除的 key 数量。 |
+| `job.start-time` | `0` | 每日 TTL 清理执行的小时数（0 到 23）。超出该范围时回退为 19。 |
+
+**内置 PD 模式**
+
+仅用于单机开发调试，通过 `app.fake-pd: true` 开启。此时节点自行扮演 PD 角色，并忽略 `pdserver.address`。
+
+| 配置项 | 代码默认值 | 说明 |
+|--------|------------|------|
+| `fake-pd.store-list` | `''` | 伪集群中各 Store 节点的 gRPC 地址。 |
+| `fake-pd.peers-list` | `''` | 同一批节点的 Raft 地址。 |
+| `fake-pd.partition-count` | `3` | 分区数量。 |
+| `fake-pd.shard-count` | `3` | 每个分区的副本数。 |
+
+**诊断**
+
+| 配置项 | 代码默认值 | 说明 |
+|--------|------------|------|
+| `arthas.telnetPort` | `8566` | 调用 `/v1/arthasstart` 后 Arthas 的 telnet 端口。 |
+| `arthas.httpPort` | `8565` | Arthas HTTP 端口。 |
+| `arthas.ip` | `0.0.0.0` | Arthas 监听地址。 |
+| `arthas.disabledCommands` | `jad` | 需要禁用的 Arthas 命令。 |
+
+#### 4.4 各节点需要区分的配置
+
 对于多节点部署，需要为每个 Store 节点修改以下配置：
 
-1. 每个节点的 `grpc.port`（RPC 端口）
-2. 每个节点的 `raft.address`（Raft 协议端口）
-3. 每个节点的 `server.port`（REST 端口）
-4. 每个节点的 `app.data-path`（数据存储路径）
+1. `grpc.host` 和 `grpc.port`（其他组件访问本节点的地址）
+2. `raft.address`（Raft 协议地址）
+3. `server.port`（REST 端口）
+4. `app.data-path`（数据存储路径）
+
+`pdserver.address` 在所有节点上保持一致，它列出的是整个 PD 集群。
 
 ### 5 启动与停止
 
@@ -162,10 +341,23 @@ logging:
 ./bin/start-hugegraph-store.sh
 ```
 
-启动脚本支持 `-d` 参数控制守护进程模式：
+启动脚本支持四个参数：
 
-- `-d true`（默认）：以后台守护进程方式运行，脚本立即返回。
-- `-d false`：以前台模式运行——脚本通过 `exec` 替换为 Java 进程，容器/进程管理器的进程即为 Java 本身。在 Docker 或进程管理器（systemd、supervisord）下运行时请使用此参数，以便在崩溃时自动检测并重启服务。
+| 参数 | 取值 | 默认值 | 说明 |
+|------|------|--------|------|
+| `-d` | `true`、`false` | `true` | 守护进程模式，见下文。 |
+| `-g` | `ZGC`、`zgc` | 未设置 | 垃圾回收器。不传该参数即使用默认的 G1。除 `ZGC` 和 `zgc` 之外的任何取值都会直接退出，包括 `g1`，尽管脚本自身的用法提示里写了它。 |
+| `-j` | JVM 参数字符串 | 空 | 附加的 JVM 参数，例如 `-j "-Xmx16g -Xms8g"`。 |
+| `-y` | `true`、`false` | `false` | 挂载 OpenTelemetry Java agent（首次使用时下载到 `plugins/`），并将 trace 导出到 `127.0.0.1:4317`。 |
+
+守护进程模式：
+
+- `-d true`（默认）：以后台守护进程方式运行，脚本立即返回，并把 Java 进程号写入 `bin/pid`。
+- `-d false`：以前台模式运行，脚本通过 `exec` 替换为 Java 进程，容器或进程管理器的进程即为 Java 本身。在 Docker 或进程管理器（systemd、supervisord）下运行时请使用此参数，以便在崩溃时自动检测并重启服务。
+
+JVM 内存方面，如果没有自行设置 `JAVA_OPTIONS`：`-Xms512m`，`-Xmx` 取空闲内存的一半并限制在 512 MB 到 2048 MB 之间。脚本还会加上 `-XX:MetaspaceSize=256M`、OOM 时把堆转储写入 `logs/`，以及滚动的 GC 日志 `logs/gc.log`。生产节点通常需要大得多的堆，请显式指定，例如 `-j "-Xmx32g -Xms32g"`。
+
+当 `ulimit -n` 或 `ulimit -u` 低于 1024 时脚本会拒绝启动；在 x86_64 和 arm64 上，如果能成功下载并校验对应的动态库，脚本会预加载 jemalloc。
 
 启动成功后，可以在 `logs/hugegraph-store-server.log` 中看到类似以下的日志：
 
@@ -180,6 +372,24 @@ YYYY-mm-dd xx:xx:xx [main] [INFO] o.a.h.s.n.StoreNodeApplication - Started Store
 ```bash
 ./bin/stop-hugegraph-store.sh
 ```
+
+脚本读取 `bin/pid`，向该进程发送信号，最多等待 30 秒直至进程退出，然后删除 pid 文件。如果 `bin/pid` 不存在，脚本直接退出且不做任何操作。
+
+#### 5.3 重启 Store
+
+```bash
+./bin/restart-hugegraph-store.sh
+```
+
+该脚本依次 source 停止脚本和启动脚本，并转发 5.1 中的参数。
+
+#### 5.4 启动顺序
+
+1. **先启动 PD**。每个 Store 的 `grpc.host:grpc.port` 都应出现在 PD 的 `pd.initial-store-list` 中，否则 PD 只会把该节点登记为 `Pending` 而不会置为 `Up`，分区分配也就无法完成。
+2. **再启动 Store**。Store 早于 PD 启动并不致命：心跳线程会持续重试注册，并在 PD 可用之前打印 `store heartbeat error: PD UNREACHABLE`。
+3. **最后启动 HugeGraph-Server**，此时所有 Store 节点都应上报 `state: "Up"`。Server 需要分区就绪之后才能初始化或打开图。
+
+compose 文件用 `depends_on: condition: service_healthy` 表达同样的顺序：Store 等待所有 PD 健康检查通过，Server 等待所有 Store 健康检查通过。
 
 ### 6 多节点部署示例
 
@@ -242,12 +452,18 @@ pdserver:
   address: 127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688
 ```
 
+同时每个 PD 节点都应列出三个 Store 的 gRPC 地址：
+```yaml
+pd:
+  initial-store-list: 127.0.0.1:8500,127.0.0.1:8501,127.0.0.1:8502
+```
+
 #### 6.3 Docker 分布式集群配置
 
 3 节点 Store 集群包含在 `docker/docker-compose-3pd-3store-3server.yml` 中。每个 Store 节点拥有独立的主机名和环境变量：
 
 ```yaml
-# store0
+# store0，宿主机端口 8500（gRPC）、8510（Raft）、8520（REST）
 HG_STORE_PD_ADDRESS: pd0:8686,pd1:8686,pd2:8686
 HG_STORE_GRPC_HOST: store0
 HG_STORE_GRPC_PORT: "8500"
@@ -255,16 +471,16 @@ HG_STORE_REST_PORT: "8520"
 HG_STORE_RAFT_ADDRESS: store0:8510
 HG_STORE_DATA_PATH: /hugegraph-store/storage
 
-# store1
-HG_STORE_PD_ADDRESS: pd0:8686,pd1:8686,pd2:8686
+# store1，宿主机端口 8501、8511、8521
 HG_STORE_GRPC_HOST: store1
 HG_STORE_RAFT_ADDRESS: store1:8510
 
-# store2
-HG_STORE_PD_ADDRESS: pd0:8686,pd1:8686,pd2:8686
+# store2，宿主机端口 8502、8512、8522
 HG_STORE_GRPC_HOST: store2
 HG_STORE_RAFT_ADDRESS: store2:8510
 ```
+
+每个节点的容器内端口都是 8500/8510/8520，只有映射到宿主机的端口不同。PD 节点相应地设置 `HG_PD_INITIAL_STORE_LIST: store0:8500,store1:8500,store2:8500`。
 
 Store 节点仅在所有 PD 节点通过健康检查后才会启动，其中 docker-compose 中的 healthcheck 实际访问的是 PD 的 REST 接口 `/v1/health`（也可以通过 Actuator 暴露的 `/actuator/health` 进行手动检查），并通过 `depends_on: condition: service_healthy` 强制执行依赖关系。
 
@@ -282,13 +498,46 @@ curl http://localhost:8520/actuator/health
 
 如果返回 `{"status":"UP"}`，则表示 Store 服务已成功启动。
 
+`GET /v1/health` 是 Docker 镜像和 compose 文件使用的轻量检查接口，它返回 HTTP 200 且响应体为空，因此应使用 `curl -fsS` 并检查退出码，而不是检查输出内容：
+
+```bash
+curl -fsS http://localhost:8520/v1/health && echo OK
+```
+
+#### 7.1 Store REST 接口
+
+Store 节点在 `server.port` 上提供以下只读接口：
+
+| 方法 | 路径 | 描述 |
+|------|------|------|
+| GET | `/v1/health` | 存活探测，HTTP 200 且响应体为空 |
+| GET | `/actuator/health` | Spring Boot Actuator 健康检查，返回 `{"status":"UP"}` |
+| GET | `/actuator/prometheus` | Prometheus 抓取接口 |
+| GET | `/` | 节点概览，包含 `leaderCount` 和 `partitionCount` |
+| GET | `/-/state` | 节点状态，取值为 `STARTING`、`ONLINE`、`STOPPING` |
+| GET | `/-/echo?name=<text>` | 回显检查 |
+| GET | `/-/scan` | 当前扫描流的状态 |
+| GET | `/v1/partitions` | 本节点上的所有 Raft 组及分区指标。加上 `?flags=accurate` 可获取精确的 key 数量，但更慢。 |
+| GET | `/v1/partition/{id}` | 按分区 id 查询单个 Raft 组，包含角色、leader、peers 和已提交索引 |
+| GET | `/metrics/system` | 主机 CPU 和内存指标 |
+| GET | `/metrics/drive` | 数据路径所在磁盘的指标 |
+| GET | `/metrics/raft` | JRaft 节点指标，需要 `raft.metrics: true` |
+
+Actuator 和 Prometheus 之所以可访问，是因为自带配置设置了 `management.endpoints.web.exposure.include: "*"` 和 `management.metrics.export.prometheus.enabled: true`。
+
+节点还提供一批会修改状态或执行重负载操作的运维接口：`PUT /-/state`、`GET /-/cleaner`、`GET /v1/partition/dump/{id}`、`GET /v1/partition/clean/{id}`、`POST /v1/compat?id=<partition>`、`GET /v1/arthasstart`、`POST /raft/options`，以及 `/fix/*` 和 `/test/*` 两组接口。请仅在排查问题时使用，并且不要把 REST 端口暴露到不可信网络。
+
+#### 7.2 通过 PD 检查注册结果
+
 也可以通过 PD API 查看集群中的 Store 节点状态：
 
 ```bash
-curl http://localhost:8620/v1/stores
+curl -u store:admin http://localhost:8620/v1/stores
 ```
 
-如果 Store 配置成功，上述接口响应中应包含当前节点的状态信息，其中 `state` 为 `Up` 表示节点运行正常。
+PD 的 REST 端口默认开启 basic 认证：用户名必须是 `hg`、`store`、`hubble`、`vermeer` 之一，密码目前还不校验。不带凭据的请求会返回 `{"status":-1,"error":"Unauthorized!"}`。只有 `/v1/health`、`/actuator/*` 和 `/v1/prom/targets/*` 不需要认证。
+
+如果 Store 配置成功，上述接口响应中应包含当前节点的状态信息，其中 `state` 为 `Up` 表示节点运行正常。如果节点长期停留在 `Pending`，通常是因为它没有出现在 PD 的 `pd.initial-store-list` 中。
 
 下方示例仅展示 1 个 Store 节点的返回结果。如果 3 个节点都已正确配置并正在运行，则响应中的 `storeId` 列表应包含 3 个 ID，且 `stateCountMap.Up`、`numOfService` 和 `numOfNormalService` 都应为 `3`。
 ```javascript

--- a/content/en/docs/quickstart/hugegraph/hugegraph-hstore.md
+++ b/content/en/docs/quickstart/hugegraph/hugegraph-hstore.md
@@ -13,12 +13,14 @@ search_boost: 1.5
 
 HugeGraph-Store is the storage node component of HugeGraph's distributed version, responsible for actually storing and managing graph data. It works in conjunction with HugeGraph-PD to form HugeGraph's distributed storage engine, providing high availability and horizontal scalability.
 
+Each Store node keeps graph data in RocksDB and replicates it with Raft (JRaft): every partition is a separate Raft group, so a partition survives the loss of a minority of its replicas. Store nodes do not know about each other directly. They register with PD, receive their partition assignment from PD, and report state back over a heartbeat. HugeGraph-Server reaches Store over gRPC after looking up partition locations in PD.
+
 ### 2 Prerequisites
 
 #### 2.1 Requirements
 
 - Operating System: Linux or macOS (Windows has not been fully tested)
-- Java version: ≥ 11
+- Java version: ≥ 11 (enforced by the build and re-checked by `bin/start-hugegraph-store.sh`)
 - Maven version: ≥ 3.5.0
 - Deploy HugeGraph-PD first for multi-node deployment
 
@@ -55,17 +57,36 @@ mvn clean install -DskipTests=true
 #    target/apache-hugegraph-{version}.tar.gz
 ```
 
+To build Store alone instead of the whole repository, build `hugegraph-struct` first, because Store depends on it:
+
+```bash
+mvn install -pl hugegraph-struct -am -DskipTests
+mvn clean package -pl hugegraph-store/hg-store-dist -am -DskipTests
+```
+
+The assembled directory contains only `bin/`, `conf/` and `lib/hg-store-node-{version}.jar`.
+
 #### 3.3 Docker Deployment
 
 The HugeGraph-Store Docker image is available on Docker Hub as `hugegraph/store`.
 
 > **Note**: The following steps assume you have already cloned or pulled the HugeGraph main repository locally, or at least have its `docker/` directory available.
 
-Use the compose file to deploy the complete 3-node cluster (PD + Store + Server):
+Two compose files include Store:
+
+| Compose file | Topology | Use |
+|--------------|----------|-----|
+| `docker-compose-hstore.yml` | 1 PD + 1 Store + 1 Server + 1 Hubble | Smallest distributed setup |
+| `docker-compose-3pd-3store-3server.yml` | 3 PD + 3 Store + 3 Server + 1 Hubble | Multi-node reference |
 
 ```bash
 cd hugegraph/docker
 # Keep the version aligned with the latest release, for example 1.x.0
+
+# Minimal distributed deployment
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-hstore.yml up -d --wait
+
+# Or the multi-node cluster
 HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
 
@@ -86,14 +107,23 @@ docker run -d \
 
 **Environment variable reference:**
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `HG_STORE_PD_ADDRESS` | Yes | — | PD gRPC addresses (e.g. `pd0:8686,pd1:8686,pd2:8686`) |
-| `HG_STORE_GRPC_HOST` | Yes | — | This node's hostname/IP for gRPC (e.g. `store0`) |
-| `HG_STORE_RAFT_ADDRESS` | Yes | — | This node's Raft address (e.g. `store0:8510`) |
-| `HG_STORE_GRPC_PORT` | No | `8500` | gRPC server port |
-| `HG_STORE_REST_PORT` | No | `8520` | REST API port |
-| `HG_STORE_DATA_PATH` | No | `/hugegraph-store/storage` | Data storage path |
+| Variable | Required | Default | Maps to | Description |
+|----------|----------|---------|---------|-------------|
+| `HG_STORE_PD_ADDRESS` | Yes | n/a | `pdserver.address` | PD gRPC addresses (e.g. `pd0:8686,pd1:8686,pd2:8686`) |
+| `HG_STORE_GRPC_HOST` | Yes | n/a | `grpc.host` | This node's hostname/IP for gRPC (e.g. `store0`) |
+| `HG_STORE_RAFT_ADDRESS` | Yes | n/a | `raft.address` | This node's Raft address (e.g. `store0:8510`) |
+| `HG_STORE_GRPC_PORT` | No | `8500` | `grpc.port` | gRPC server port |
+| `HG_STORE_REST_PORT` | No | `8520` | `server.port` | REST API port |
+| `HG_STORE_DATA_PATH` | No | `/hugegraph-store/storage` | `app.data-path` | Data storage path |
+
+The entrypoint turns these into a `SPRING_APPLICATION_JSON` overlay on top of `conf/application.yml`, then runs `bin/start-hugegraph-store.sh -d false -j "$JAVA_OPTS"`. Any key not covered by the table above still has to be edited in `conf/application.yml`, or supplied through your own `SPRING_APPLICATION_JSON`.
+
+Image details:
+
+- `JAVA_OPTS` defaults to `-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -XshowSettings:vm`
+- `STDOUT_MODE=true`, so Java logs go to the container stdout instead of `logs/hugegraph-store-server.log`
+- `HEALTHCHECK` calls `GET http://localhost:8520/v1/health` every 15s after a 90s start period
+- The image declares `EXPOSE 8520`; publish 8500 and 8510 yourself when Server or other Store nodes need to reach the container from outside the Docker network
 
 > **Note**: In Docker bridge networking, use container hostnames (e.g. `store0`) for `HG_STORE_GRPC_HOST` instead of IP addresses.
 
@@ -101,34 +131,49 @@ docker run -d \
 
 ### 4 Configuration
 
-The main configuration file for Store is `conf/application.yml`. Here are the key configuration items:
+Store reads two files from `conf/`:
+
+- `application.yml`, the main configuration file (PD address, ports, Raft, data path)
+- `application-pd.yml`, pulled in by `spring.profiles.include: pd` in `application.yml`, holding the RocksDB memory settings and the Actuator exposure
+
+#### 4.1 application.yml
+
+This is the file shipped in the distribution package:
 
 ```yaml
 pdserver:
-  # PD service address, multiple PD addresses are separated by commas (configure PD's gRPC port)
-  address: 127.0.0.1:8686
+  # PD service address, multiple PD addresses separated by commas
+  address: localhost:8686
+
+management:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
 
 grpc:
-  # gRPC service address
+  # grpc service address
   host: 127.0.0.1
   port: 8500
   netty-server:
     max-inbound-message-size: 1000MB
-
 raft:
   # raft cache queue size
   disruptorBufferSize: 1024
   address: 127.0.0.1:8510
   max-log-file-size: 600000000000
-  # Snapshot generation time interval, in seconds
+  # Snapshot generation interval, in seconds
   snapshotInterval: 1800
-
 server:
-  # REST service address
+  # rest service address
   port: 8520
 
 app:
-  # Storage path, supports multiple paths separated by commas
+  # Storage path, support multiple paths, separated by commas
   data-path: ./storage
   #raft-path: ./storage
 
@@ -145,12 +190,146 @@ logging:
     root: info
 ```
 
+#### 4.2 application-pd.yml
+
+```yaml
+management:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+rocksdb:
+  # rocksdb total memory usage, force flush to disk when reaching this value
+  total_memory_size: 32000000000
+  # memtable size used by rocksdb
+  write_buffer_size: 32000000
+  # For each rocksdb, the number of memtables reaches this value for writing to disk.
+  min_write_buffer_number_to_merge: 16
+```
+
+#### 4.3 Configuration reference
+
+"Shipped" is the value in the two files above. "Code default" is what the node falls back to when the key is absent, and is the value to rely on for keys the template does not list.
+
+**Core**
+
+| Key | Shipped | Code default | Meaning |
+|-----|---------|--------------|---------|
+| `pdserver.address` | `localhost:8686` | required | PD gRPC endpoints, comma separated. Store registers itself here and receives its partition assignment. Must be PD's `grpc.port`, not its REST port. |
+| `grpc.host` | `127.0.0.1` | required | Address this node advertises for its own gRPC service. Set it to a routable IP or hostname, `127.0.0.1` is only usable for a single-machine setup. |
+| `grpc.port` | `8500` | required | gRPC port. Server and the Store client connect here. |
+| `grpc.netty-server.max-inbound-message-size` | `1000MB` | gRPC default | Maximum size of a single inbound gRPC message. Bound by the `grpc-spring-boot-starter` Netty server. |
+| `grpc.server.wait-time` | not set | `3600` | Seconds a scan stream waits for the client to consume a page before the server aborts it. |
+| `server.port` | `8520` | required | REST and Actuator port. Also reported to PD as the `rest.port` label. |
+
+**Raft**
+
+| Key | Shipped | Code default | Meaning |
+|-----|---------|--------------|---------|
+| `raft.address` | `127.0.0.1:8510` | required | Raft service address of this node, `host:port`. Must be reachable from every other Store node. There is no peer list to configure: PD tells each node which peers belong to a partition's Raft group. |
+| `raft.disruptorBufferSize` | `1024` | `0` | Raft task queue size. `0` derives it from `rocksdb.total_memory_size`, by rounding that size in GB to the nearest power of two and multiplying by 32. |
+| `raft.max-log-file-size` | `600000000000` | `50000000000` | Maximum byte size of Raft logs. |
+| `raft.snapshotInterval` | `1800` | `300` | Seconds between Raft snapshots. |
+| `raft.snapshotLogIndexMargin` | not set | `0` | Minimum applied-index distance since the last snapshot before a snapshot is actually written. `0` disables the distance check. |
+| `raft.rpc-timeout` | not set | `10000` | Raft RPC timeout in milliseconds. |
+| `raft.metrics` | not set | `true` | Collect JRaft node metrics, readable at `/metrics/raft`. |
+| `raft.useRocksDBSegmentLogStorage` | not set | `true` | Store Raft logs in the RocksDB segment log storage. |
+| `raft.maxSegmentFileSize` | not set | `67108864` | Segment log file size in bytes (64 MB). |
+| `raft.maxReplicatorInflightMsgs` | not set | `256` | Maximum in-flight replication requests per follower. |
+| `raft.maxEntriesSize` | not set | `256` | Maximum number of entries in one `AppendEntries` request. |
+| `raft.maxBodySize` | not set | `524288` | Maximum byte size of one `AppendEntries` request. |
+| `ave-logEntry-size-ratio` | not set | `0.95` | Smoothing ratio used to estimate the average log entry size. Note that this key sits at the top level, not under `raft`. |
+
+**Storage and labels**
+
+| Key | Shipped | Code default | Meaning |
+|-----|---------|--------------|---------|
+| `app.data-path` | `./storage` | `store` | RocksDB data directory. Multiple paths separated by commas spread partitions over several disks. |
+| `app.raft-path` | commented out | empty | Directory for Raft logs and snapshots. Falls back to `app.data-path` when empty. |
+| `app.fake-pd` | not set | `false` | Built-in PD mode for standalone testing. Do not use it in production. |
+| `app.placeholder-size` | not set | `10` | Size in GB of a `placeholder` file created in each data path at startup, so space can be freed in an emergency. `0` disables it. |
+| `app.label.<name>` | not set | none | Arbitrary key/value labels sent to PD in the store heartbeat. The node adds `rest.port` on its own. |
+
+**RocksDB**
+
+| Key | Shipped | Code default | Meaning |
+|-----|---------|--------------|---------|
+| `rocksdb.total_memory_size` | `32000000000` | `51539607552` | Memory budget shared by all RocksDB instances on this node. When absent or `0`, the node uses the JVM max heap instead. |
+| `rocksdb.write_buffer_size` | `32000000` | `33554432` | Memtable size in bytes. When absent or `0`, the node uses `total_memory_size / 1000`. |
+| `rocksdb.min_write_buffer_number_to_merge` | `16` | `16` | Number of memtables merged together before a flush. |
+| `rocksdb.write_buffer_ratio` | not set | `0.66` | Share of `total_memory_size` given to the write cache. The rest becomes the block cache. |
+
+Any other option defined in `org/apache/hugegraph/rocksdb/access/RocksDBOptions.java` can be added under the same `rocksdb:` block, for example `rocksdb.max_background_jobs`, `rocksdb.level0_file_num_compaction_trigger` or `rocksdb.bloom_filter_bits_per_key`.
+
+**Thread pools**
+
+| Key | Code default | Meaning |
+|-----|--------------|---------|
+| `thread.pool.grpc.core` | `600` | Core threads serving gRPC requests. |
+| `thread.pool.grpc.max` | `1000` | Maximum gRPC threads. |
+| `thread.pool.grpc.queue` | `2147483647` | gRPC task queue capacity. |
+| `thread.pool.scan.core` | `128` | Core threads serving scans. `0` means 4 times the CPU count. |
+| `thread.pool.scan.max` | `1000` | Maximum scan threads. |
+| `thread.pool.scan.queue` | `0` | Scan task queue capacity. |
+
+**Query pushdown**
+
+| Key | Code default | Meaning |
+|-----|--------------|---------|
+| `query.push-down.threads` | `1500` | Thread pool size for pushed-down queries. |
+| `query.push-down.fetch_batch` | `20000` | Rows fetched per request. |
+| `query.push-down.fetch_timeout` | `300000` | Fetch timeout in milliseconds. |
+| `query.push-down.memory_limit_count` | `50000` | Row limit for in-memory operations such as sorting. |
+| `query.push-down.index_size_limit_count` | `50000` | Index sst file size limit in kB. |
+
+**Background jobs**
+
+| Key | Code default | Meaning |
+|-----|--------------|---------|
+| `job.interruptableThreadPool.core` | `128` | Core threads of the TTL cleaner pool. `0` means the CPU count. |
+| `job.interruptableThreadPool.max` | `256` | Maximum threads of the TTL cleaner pool. `0` means 4 times the CPU count. |
+| `job.interruptableThreadPool.queue` | `2147483647` | Queue capacity of the TTL cleaner pool. |
+| `job.uninterruptibleThreadPool.core` | `0` | Core threads of the engine's uninterruptible job pool. `0` means the CPU count. |
+| `job.uninterruptibleThreadPool.max` | `256` | Maximum threads of the uninterruptible job pool. |
+| `job.uninterruptibleThreadPool.queue` | `2147483647` | Queue capacity of the uninterruptible job pool. |
+| `job.cleaner.batch.size` | `10000` | Keys deleted per batch by the TTL cleaner. |
+| `job.start-time` | `0` | Hour of day (0 to 23) at which the daily TTL cleanup runs. Values outside that range fall back to 19. |
+
+**Built-in PD mode**
+
+Only for single-node development and debugging, activated by `app.fake-pd: true`. The node then plays PD's role itself and ignores `pdserver.address`.
+
+| Key | Code default | Meaning |
+|-----|--------------|---------|
+| `fake-pd.store-list` | `''` | gRPC addresses of the Store nodes in the fake cluster. |
+| `fake-pd.peers-list` | `''` | Raft addresses of the same nodes. |
+| `fake-pd.partition-count` | `3` | Number of partitions. |
+| `fake-pd.shard-count` | `3` | Replicas per partition. |
+
+**Diagnostics**
+
+| Key | Code default | Meaning |
+|-----|--------------|---------|
+| `arthas.telnetPort` | `8566` | Arthas telnet port, used when `/v1/arthasstart` is called. |
+| `arthas.httpPort` | `8565` | Arthas HTTP port. |
+| `arthas.ip` | `0.0.0.0` | Arthas bind address. |
+| `arthas.disabledCommands` | `jad` | Arthas commands to disable. |
+
+#### 4.4 Per-node changes
+
 For multi-node deployment, you need to modify the following configurations for each Store node:
 
-1. `grpc.port` (RPC port) for each node
-2. `raft.address` (Raft protocol port) for each node
-3. `server.port` (REST port) for each node
-4. `app.data-path` (data storage path) for each node
+1. `grpc.host` and `grpc.port` (the address other components dial)
+2. `raft.address` (Raft protocol address)
+3. `server.port` (REST port)
+4. `app.data-path` (data storage path)
+
+`pdserver.address` is the same on every node, it lists the whole PD cluster.
 
 ### 5 Start and Stop
 
@@ -162,10 +341,23 @@ Ensure that the PD service is already started, then in the Store installation di
 ./bin/start-hugegraph-store.sh
 ```
 
-The startup script supports a `-d` flag to control daemon mode:
+The script accepts four flags:
 
-- `-d true` (default): run as a background daemon; the script returns immediately.
-- `-d false`: run in foreground — the script `exec`s Java, so the container/supervisor process IS Java. Use this when running under Docker or a process supervisor (systemd, supervisord) so crashes are detected and the service is restarted automatically.
+| Flag | Values | Default | Description |
+|------|--------|---------|-------------|
+| `-d` | `true`, `false` | `true` | Daemon mode. See below. |
+| `-g` | `ZGC`, `zgc` | not set | Garbage collector. Omit the flag for G1, which is the default. Any value other than `ZGC` or `zgc` aborts the start, including `g1`, even though the script's own usage line suggests it. |
+| `-j` | JVM options string | empty | Extra JVM options, for example `-j "-Xmx16g -Xms8g"`. |
+| `-y` | `true`, `false` | `false` | Attach the OpenTelemetry Java agent, downloading it into `plugins/` on first use, and export traces to `127.0.0.1:4317`. |
+
+Daemon mode:
+
+- `-d true` (default): run as a background daemon. The script returns immediately and writes the Java pid to `bin/pid`.
+- `-d false`: run in the foreground. The script `exec`s Java, so the container or supervisor process is Java itself. Use this under Docker or a process supervisor (systemd, supervisord) so crashes are detected and the service is restarted automatically.
+
+JVM memory, unless you set `JAVA_OPTIONS` yourself: `-Xms512m`, and `-Xmx` set to half the free memory, clamped to the 512 MB to 2048 MB range. The script also adds `-XX:MetaspaceSize=256M`, a heap dump on out-of-memory into `logs/`, and a rolling GC log at `logs/gc.log`. Production nodes normally need a much larger heap, so pass one explicitly, for example `-j "-Xmx32g -Xms32g"`.
+
+The script refuses to start if `ulimit -n` or `ulimit -u` is below 1024, and it preloads jemalloc on x86_64 and arm64 when the shared object can be downloaded and verified.
 
 After successful startup, you can see logs similar to the following in `logs/hugegraph-store-server.log`:
 
@@ -180,6 +372,24 @@ In the Store installation directory, execute:
 ```bash
 ./bin/stop-hugegraph-store.sh
 ```
+
+The script reads `bin/pid`, signals that process, and waits up to 30 seconds for it to exit before removing the pid file. If `bin/pid` is missing it exits without doing anything.
+
+#### 5.3 Restart Store
+
+```bash
+./bin/restart-hugegraph-store.sh
+```
+
+It sources the stop script and then the start script, and forwards the flags from section 5.1.
+
+#### 5.4 Startup order
+
+1. **PD** first. Each Store's `grpc.host:grpc.port` should appear in PD's `pd.initial-store-list`, otherwise PD registers the node in `Pending` state instead of bringing it to `Up`, and partition assignment never finishes.
+2. **Store** next. A Store started before PD is reachable is not fatal: the heartbeat thread keeps retrying registration and logs `store heartbeat error: PD UNREACHABLE` until PD answers.
+3. **HugeGraph-Server** last, once every Store node reports `state: "Up"`. Server needs the partitions in place before it can initialize or open a graph.
+
+The compose files encode the same order with `depends_on: condition: service_healthy`: Store waits for every PD healthcheck, and Server waits for every Store healthcheck.
 
 ### 6 Multi-Node Deployment Example
 
@@ -242,12 +452,18 @@ pdserver:
   address: 127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688
 ```
 
+And every PD node should list all three Store gRPC addresses:
+```yaml
+pd:
+  initial-store-list: 127.0.0.1:8500,127.0.0.1:8501,127.0.0.1:8502
+```
+
 #### 6.3 Docker Distributed Cluster Configuration
 
 The distributed Store cluster definition is included in `docker/docker-compose-3pd-3store-3server.yml`. Each Store node gets its own hostname and environment variables:
 
 ```yaml
-# store0
+# store0, published as 8500 (gRPC), 8510 (Raft), 8520 (REST)
 HG_STORE_PD_ADDRESS: pd0:8686,pd1:8686,pd2:8686
 HG_STORE_GRPC_HOST: store0
 HG_STORE_GRPC_PORT: "8500"
@@ -255,16 +471,16 @@ HG_STORE_REST_PORT: "8520"
 HG_STORE_RAFT_ADDRESS: store0:8510
 HG_STORE_DATA_PATH: /hugegraph-store/storage
 
-# store1
-HG_STORE_PD_ADDRESS: pd0:8686,pd1:8686,pd2:8686
+# store1, published as 8501, 8511, 8521
 HG_STORE_GRPC_HOST: store1
 HG_STORE_RAFT_ADDRESS: store1:8510
 
-# store2
-HG_STORE_PD_ADDRESS: pd0:8686,pd1:8686,pd2:8686
+# store2, published as 8502, 8512, 8522
 HG_STORE_GRPC_HOST: store2
 HG_STORE_RAFT_ADDRESS: store2:8510
 ```
+
+The container ports stay 8500/8510/8520 on every node, only the published host ports differ. The PD nodes set `HG_PD_INITIAL_STORE_LIST: store0:8500,store1:8500,store2:8500` to match.
 
 Store nodes start only after all PD nodes pass healthchecks (`/v1/health`), enforced via `depends_on: condition: service_healthy`.
 
@@ -282,13 +498,46 @@ curl http://localhost:8520/actuator/health
 
 If it returns `{"status":"UP"}`, it indicates that the Store service has been successfully started.
 
+`GET /v1/health` is the lighter check used by the Docker image and the compose files. It answers HTTP 200 with an empty body, so use `curl -fsS` and check the exit code rather than the output:
+
+```bash
+curl -fsS http://localhost:8520/v1/health && echo OK
+```
+
+#### 7.1 Store REST endpoints
+
+The Store node exposes these read-only endpoints on `server.port`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/health` | Liveness probe, HTTP 200 with an empty body |
+| GET | `/actuator/health` | Spring Boot Actuator health, `{"status":"UP"}` |
+| GET | `/actuator/prometheus` | Prometheus scrape endpoint |
+| GET | `/` | Node summary, `leaderCount` and `partitionCount` |
+| GET | `/-/state` | Node state, one of `STARTING`, `ONLINE`, `STOPPING` |
+| GET | `/-/echo?name=<text>` | Echo check |
+| GET | `/-/scan` | State of the running scan streams |
+| GET | `/v1/partitions` | All Raft groups on this node with per-partition metrics. Add `?flags=accurate` for exact key counts, which is slower. |
+| GET | `/v1/partition/{id}` | One Raft group by partition id, including role, leader, peers and committed index |
+| GET | `/metrics/system` | Host CPU and memory metrics |
+| GET | `/metrics/drive` | Disk metrics for the data paths |
+| GET | `/metrics/raft` | JRaft node metrics, needs `raft.metrics: true` |
+
+Actuator and Prometheus are reachable because the shipped configuration sets `management.endpoints.web.exposure.include: "*"` and `management.metrics.export.prometheus.enabled: true`.
+
+The node also serves maintenance endpoints that change state or run heavy work: `PUT /-/state`, `GET /-/cleaner`, `GET /v1/partition/dump/{id}`, `GET /v1/partition/clean/{id}`, `POST /v1/compat?id=<partition>`, `GET /v1/arthasstart`, `POST /raft/options`, and the `/fix/*` and `/test/*` groups. Use them only for troubleshooting, and keep the REST port off untrusted networks.
+
+#### 7.2 Check registration from PD
+
 You can also check Store node status through the PD API:
 
 ```bash
-curl http://localhost:8620/v1/stores
+curl -u store:admin http://localhost:8620/v1/stores
 ```
 
-If Store is configured successfully, the response should include status information for the current node, and `state: "Up"` means the node is running normally.
+PD requires basic auth on its REST port. The user name must be one of `hg`, `store`, `hubble`, `vermeer`, and the password is not validated yet. A call with no credentials returns `{"status":-1,"error":"Unauthorized!"}`. Only `/v1/health`, `/actuator/*` and `/v1/prom/targets/*` are exempt.
+
+If Store is configured successfully, the response should include status information for the current node, and `state: "Up"` means the node is running normally. A node stuck at `Pending` is usually missing from PD's `pd.initial-store-list`.
 
 The example below shows a single Store node. If all three nodes are configured correctly and running, the `storeId` list should contain three IDs, and `stateCountMap.Up`, `numOfService`, and `numOfNormalService` should all be `3`.
 


### PR DESCRIPTION
Syncs the HugeGraph-Store quickstart page with `apache/hugegraph` master (commit `36811483a`). Both `content/en` and `content/cn` are updated.

| page | what was wrong | what changed | source (file:line on master) |
|------|----------------|--------------|------------------------------|
| quickstart/hugegraph/hugegraph-hstore.md | The `application.yml` block did not match the shipped template: `pdserver.address` was shown as `127.0.0.1:8686` and the whole `management` block was missing | Block now mirrors the shipped file byte for byte, `pdserver.address: localhost:8686` plus the `management` section | hugegraph-store/hg-store-dist/src/assembly/static/conf/application.yml:18-63 |
| quickstart/hugegraph/hugegraph-hstore.md | `application-pd.yml` and its `rocksdb.*` keys were not documented at all, even though `spring.profiles.include: pd` pulls the file in | New section 4.2 with the file contents, and a RocksDB table for `total_memory_size`, `write_buffer_size`, `min_write_buffer_number_to_merge`, `write_buffer_ratio` | hugegraph-store/hg-store-dist/src/assembly/static/conf/application-pd.yml:18-34; hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBOptions.java:36-53,220-240; hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/options/RaftRocksdbOptions.java:144-153 |
| quickstart/hugegraph/hugegraph-hstore.md | No defaults or meanings for any config key, and most keys the node reads were missing (`app.fake-pd`, `app.raft-path`, `app.placeholder-size`, `app.label.*`, `grpc.server.wait-time`, ten `raft.*` keys, `ave-logEntry-size-ratio`, `thread.pool.*`, `query.push-down.*`, `job.*`, `fake-pd.*`, `arthas.*`) | New section 4.3 with per-prefix tables giving each key its template value, code default and meaning | hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/AppConfig.java:40-313; hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/listener/PlaceHolderListener.java:41-68; hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/task/TTLCleaner.java:107-113,279 |
| quickstart/hugegraph/hugegraph-hstore.md | Only the `-d` start flag was documented | Flag table for `-d`, `-g`, `-j`, `-y`, including that `-g g1` actually aborts the start even though the script's usage line suggests it, plus the real default heap (`-Xms512m`, `-Xmx` between 512 MB and 2048 MB), the ulimit preflight and jemalloc preload | hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh:45-176; hugegraph-store/hg-store-dist/src/assembly/static/bin/util.sh:179-197 |
| quickstart/hugegraph/hugegraph-hstore.md | `restart-hugegraph-store.sh` was not mentioned, and the stop script's behavior was not described | New section 5.3 for restart, and the stop section now explains the `bin/pid` file and the 30 second shutdown wait | hugegraph-store/hg-store-dist/src/assembly/static/bin/restart-hugegraph-store.sh:30-32; hugegraph-store/hg-store-dist/src/assembly/static/bin/stop-hugegraph-store.sh:35-48 |
| quickstart/hugegraph/hugegraph-hstore.md | Startup order relative to PD and Server was a single sentence, and the `pd.initial-store-list` requirement was missing | New section 5.4: PD, then Store, then Server, plus the fact that a Store absent from `pd.initial-store-list` registers as `Pending` and never reaches `Up`, and that Store retries registration when PD is unreachable | hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/StoreNodeService.java:161-167,218-220; hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/HeartbeatService.java:123-160; docker/docker-compose-3pd-3store-3server.yml:46-60,74-90 |
| quickstart/hugegraph/hugegraph-hstore.md | `/actuator/health` was the only endpoint listed, and `/v1/health` was described only in the Docker section | New section 7.1 listing the endpoints that exist in `hg-store-node`: `/v1/health`, `/actuator/health`, `/actuator/prometheus`, `/`, `/-/state`, `/-/echo`, `/-/scan`, `/v1/partitions`, `/v1/partition/{id}`, `/metrics/system`, `/metrics/drive`, `/metrics/raft`, with a note on the maintenance endpoints | hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/controller/HgStoreStatusController.java:49-117; .../IndexAPI.java:48-54; .../PartitionAPI.java:66-205; .../HgStoreMetricsController.java:46-62; .../RaftAPI.java:42-45; .../FixGraphIdController.java:64-479 |
| quickstart/hugegraph/hugegraph-hstore.md | Docker section listed only `docker-compose-3pd-3store-3server.yml` and called it a 3 node cluster | Added `docker-compose-hstore.yml` (1 PD + 1 Store + 1 Server + 1 Hubble) and corrected both topologies to include Hubble | docker/docker-compose-hstore.yml:53-103; docker/docker-compose-3pd-3store-3server.yml:96-231; docker/README.md:16-17 |
| quickstart/hugegraph/hugegraph-hstore.md | The env var table did not say which config key each variable sets, and the image behavior was undocumented | Added a "Maps to" column, plus the `SPRING_APPLICATION_JSON` mechanism, `JAVA_OPTS` default, `STDOUT_MODE=true`, the `HEALTHCHECK` parameters and the fact that only 8520 is declared `EXPOSE` | hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh:45-80; hugegraph-store/Dockerfile:42-69 |
| quickstart/hugegraph/hugegraph-hstore.md | Docker cluster snippet did not explain that only the host ports differ between store0/1/2, and did not mention the matching PD setting | Snippet now labels the published host ports per node and notes `HG_PD_INITIAL_STORE_LIST: store0:8500,store1:8500,store2:8500` | docker/docker-compose-3pd-3store-3server.yml:151-194,107 |
| quickstart/hugegraph/hugegraph-hstore.md | Building Store on its own was not covered | Added the `hugegraph-struct` first step and the `hg-store-dist` package command, plus what the assembled directory contains | hugegraph-store/hg-store-dist/src/assembly/descriptor/server-assembly.xml:27-60; hugegraph-store/AGENTS.md:62-67,187 |
| quickstart/hugegraph/hugegraph-hstore.md (cn only) | The tar extraction step used `apache-hugegraph-hstore-incubating-1.7.0`, which is not the directory the release produces | Corrected to `apache-hugegraph-store-incubating-1.7.0`, matching the en page | hugegraph-store/pom.xml:48; install-dist/pom.xml:54 |
| quickstart/hugegraph/hugegraph-hstore.md | Overview did not say how storage and replication actually work | Added one paragraph: RocksDB per node, one Raft group per partition, PD assigns partitions and Store reports back over heartbeat, Server reaches Store over gRPC | hugegraph-store/README.md:10,77-79; hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/options/HgStoreEngineOptions.java:34-72 |
| quickstart/hugegraph/hugegraph-hstore.md | Em dashes were used as the "no default" marker and in the daemon mode note | Replaced with `n/a` and plain punctuation | n/a |
| quickstart/hugegraph/hugegraph-hstore.md | The PD registration check ran `curl http://localhost:8620/v1/stores` with no credentials, which PD rejects with `{"status":-1,"error":"Unauthorized!"}` | The call now sends `-u store:admin`, with a note that the user name must be one of `hg`, `store`, `hubble`, `vermeer`, that the password is not validated yet, and that only `/v1/health`, `/actuator/*` and `/v1/prom/targets/*` skip the interceptor | hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/interceptor/AuthenticationConfigurer.java:33-35; hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/interceptor/RestAuthentication.java:48-53; hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/service/interceptor/Authentication.java:62,79-87 |

