### PR TITLE
doc(toolchain): sync hubble with master

### DIFF
--- a/content/cn/docs/quickstart/toolchain/hugegraph-hubble.md
+++ b/content/cn/docs/quickstart/toolchain/hugegraph-hubble.md
@@ -6,35 +6,57 @@ weight: 1
 
 ### 1 HugeGraph-Hubble 概述
 
-> ⚠️ **安全提醒**：截至 1.7.0 发布版，Hubble 尚未提供 Auth/Login 登录保护；相关功能计划随 1.8.0 发布。请勿将 Hubble 暴露在公网或不受信任的网络中，并使用 IP/端口白名单和 HTTPS 限制访问。
+> ⚠️ **安全提醒**：Hubble 监听的是明文 HTTP 端口，请勿将其暴露在公网或不受信任的网络中；应在其前面终结 HTTPS，并使用 IP/端口白名单限制访问。Hubble 自身不保存账号库：当所连接的 HugeGraph Server 开启了鉴权时，Hubble 会显示登录页并把凭据转发给 Server；当 Server 允许匿名访问时，则没有登录环节，账号相关页面也会隐藏。
+>
+> **版本说明**：本页对应 hugegraph-toolchain `master`。下文标注了依赖较新 Server、PD 或 Store 版本的功能，这些功能在旧版 Server 上不可用。
 >
 > **测试指南**：如需在本地运行 Hubble 测试，请参考 [工具链本地测试指南](/cn/docs/guides/toolchain-local-test)
 
-HugeGraph-Hubble 是 HugeGraph 的 Web 管理界面，可用于管理图连接和 Schema、导入数据、执行 Gremlin 查询并查看图形化结果。
+HugeGraph-Hubble 是 HugeGraph 的 Web 管理界面。它连接到一个 HugeGraph Server（直连，或在分布式集群中通过 PD 发现），管理图空间（GraphSpace）、图和 Schema，导入数据，执行 Gremlin 与 Cypher 查询以及内置图算法，并将结果图形化展示。
 
 平台主要包括以下模块：
 
-##### 图管理
+##### 图概览
 
-图管理用于创建和维护连接，可在多个图之间切换，并执行访问、编辑、删除和查询操作。
+图概览列出图空间（PD 模式）和图，可以创建、克隆和清空图，加载 Demo 图，打开包含统计信息与 Schema 的图详情页，并跳转到查询工作台。
 
 ##### 元数据建模
 
-元数据建模用于管理 PropertyKey、VertexLabel、EdgeLabel 和 IndexLabel。页面提供列表与图两种视图，也可以在图之间复用元数据。
+元数据建模用于管理单个图的 PropertyKey、VertexLabel、EdgeLabel 和 IndexLabel，提供列表与图两种视图。Schema 模板按图空间保存可复用的 Groovy Schema，可在创建图时直接套用。
 
-##### 图分析
-
-图分析页面可以执行 Gremlin 和路径查询，并用图、表格或 JSON 显示结果。页面还保存执行记录和收藏语句，查询结果可以导出为 JSON。
-
-##### 任务管理
-
-任务管理页面用于查看 Gremlin 异步任务、索引创建和重建等后台任务。
-
-##### 数据导入 (BETA)
+##### 数据导入
 
 > 数据导入页面适合小规模试用。大批量或生产导入请使用 [HugeGraph Loader](/cn/docs/quickstart/toolchain/hugegraph-loader)。
 
-数据导入页面按步骤创建任务、上传文件并配置字段映射，可并行运行多个导入任务，也支持断点续传和错误重试。
+数据源支持 FILE、HDFS、JDBC 和 KAFKA 四种类型。导入任务分四步配置，可以执行一次、按 cron 周期执行，或对 Kafka 源持续实时执行。
+
+##### 图查询
+
+图查询可以按立即查询或异步任务两种模式执行 Gremlin 与 Cypher 语句，并以图（2D 或 3D）、表格或 JSON 展示结果，同时保存执行记录与收藏语句。
+
+##### 内置图算法
+
+内置图算法为 Server 的 OLTP traverser 接口（交互式探索）以及 OLAP 任务（通过 HugeGraph Computer 或 Vermeer 进行集群批量计算）提供参数表单。
+
+##### 异步任务
+
+异步任务列出后台任务，包括 Gremlin 与 Cypher 任务、算法任务、删除元数据、创建与重建索引、Vermeer 图加载与图计算任务，并支持查看详情、取消和删除。
+
+##### 系统与运维
+
+系统与运维包含个人中心、带图空间权限预设的账号管理，以及 PD 模式下的集群概览与节点详情。
+
+#### 1.1 版本兼容性
+
+Hubble 会自动探测所连接 Server 的鉴权模式与能力，自身没有单独的鉴权开关。支持的组合如下：
+
+| HugeGraph Server / PD | 部署方式 | Hubble 兼容性 | 范围与限制 |
+|---|---|---|---|
+| Server 1.5.x | 单机，通常不开启鉴权 | 最低兼容 | 仅支持基础的图、Schema、数据和 Gremlin 流程。图空间、账号权限、PD/Store 拓扑、集群运维和较新的算法均不可用。 |
+| Server 1.7.x 搭配同版本 PD/Store 1.7.x | 单机或分布式 | 通过兼容适配达到最低可用 | 核心管理与查询流程仍可使用，但旧版 REST/Gremlin 鉴权、权限语义、指标和算法能力的体验会有所降级。 |
+| Server、PD 和 Store 1.8.x 及以上 | 推荐分布式部署 | 完整且推荐的体验 | 图空间、账号权限预设、集群运维、异步任务和算法能力处理都是针对这一代设计并验证的。 |
+
+分布式集群中请使用版本号一致的 Server、PD 和 Store。
 
 ### 2 部署
 
@@ -44,15 +66,34 @@ HugeGraph-Hubble 是 HugeGraph 的 Web 管理界面，可用于管理图连接�
 - 下载 toolchain 二进制包
 - 源码编译
 
+Hubble 运行在 Java 11 上：后端以 `java.version=11` 编译，Docker 镜像基于 `eclipse-temurin:11-jre`。`bin/start-hubble.sh` 只检查 `PATH` 中是否存在 `java`，因此请自行确认选用的是正确的 JDK。
+
 #### 2.1 使用 Docker (便于**测试**)
 
-> **特别注意**: docker 模式下，若 hubble 和 server 在同一宿主机，hubble 页面中设置 server 的 `hostname` **不能设置**为 `localhost/127.0.0.1`，因这会指向 hubble **容器内部**而非宿主机，导致无法连接到 server.
-> 
+> **特别注意**：Hubble 已不再在页面上填写 Server 的主机名和端口。Server 地址来自 `conf/hugegraph-hubble.properties`：`pd.enabled=false` 时使用 `server.direct_url`，`pd.enabled=true` 时通过 `pd.peers` 由 PD 发现。容器内的 `127.0.0.1` 指向 hubble 容器自身，因此打包默认值 `server.direct_url=http://127.0.0.1:8080` 无法访问到另一个容器里的 Server。
+>
 > 若 hubble 和 server 在同一 docker 网络下，**推荐**直接使用`container_name` (如下例的 `server`) 作为主机名。或者也可以使用 **宿主机 IP** 作为主机名，此时端口号为宿主机给 server 配置的端口
 
-我们可以使用 `docker run -itd --name=hubble -p 8088:8088 hugegraph/hubble:1.5.0` 快速启动 [hubble](https://hub.docker.com/r/hugegraph/hubble).
+镜像会把打包产物复制到 `/hubble`，把 `/hubble/conf/hugegraph-hubble.properties` 中的 `server.host` 改写为 `0.0.0.0`、清空 `dashboard.address`，暴露 `8088` 端口，并以 `./bin/start-hubble.sh -f` 前台方式启动。
 
-或者使用 docker-compose 启动 hubble，另外如果 hubble 和 server 在同一个 docker 网络下，可以使用 server 的 contain_name 进行访问，而不需要宿主机的 ip
+先准备一份指向你的 Server、并让容器监听所有网卡的 `hugegraph-hubble.properties`：
+
+```properties
+server.host=0.0.0.0
+server.port=8088
+pd.enabled=false
+server.direct_url=http://server:8080
+```
+
+然后把该文件挂载覆盖打包配置来启动 [hubble](https://hub.docker.com/r/hugegraph/hubble)：
+
+```bash
+docker run -itd --name=hubble -p 8088:8088 \
+  -v "$PWD/hugegraph-hubble.properties:/hubble/conf/hugegraph-hubble.properties" \
+  hugegraph/hubble:1.7.0
+```
+
+或者使用 docker-compose 启动 hubble，另外如果 hubble 和 server 在同一个 docker 网络下，可以使用 server 的 container_name 进行访问，而不需要宿主机的 ip
 
 使用`docker-compose up -d`，`docker-compose.yml`如下：
 
@@ -60,7 +101,7 @@ HugeGraph-Hubble 是 HugeGraph 的 Web 管理界面，可用于管理图连接�
 version: '3'
 services:
   server:
-    image: hugegraph/hugegraph:1.5.0
+    image: hugegraph/hugegraph:1.7.0
     container_name: server
     environment:
       - PASSWORD=xxx
@@ -68,17 +109,19 @@ services:
       - 8080:8080
 
   hubble:
-    image: hugegraph/hubble:1.5.0
+    image: hugegraph/hubble:1.7.0
     container_name: hubble
     ports:
       - 8088:8088
+    volumes:
+      - ./hugegraph-hubble.properties:/hubble/conf/hugegraph-hubble.properties
 ```
 
 > 注意：
 >
 > 1. `hugegraph-hubble` 的 docker 镜像是一个便捷发布版本，用于快速测试试用 hubble，并非**ASF 官方发布物料包的方式**。你可以从 [ASF Release Distribution Policy](https://infra.apache.org/release-distribution.html#dockerhub) 中得到更多细节。
 >
-> 2. **生产环境**推荐使用 `release tag`(如 `1.5.0`) 稳定版。使用 `latest` tag 默认对应 master 最新代码。
+> 2. **生产环境**推荐使用 `release tag`(如 `1.7.0`) 稳定版。使用 `latest` tag 默认对应 master 最新代码。
 
 #### 2.2 下载 toolchain 二进制包
 
@@ -92,17 +135,28 @@ tar -xvf "${ARCHIVE}.tar.gz"
 cd "${ARCHIVE}/apache-hugegraph-hubble-incubating-${VERSION}"
 ```
 
-运行`hubble`
+先修改 `conf/hugegraph-hubble.properties`，把 Server 地址配置正确，然后运行`hubble`
 
 ```bash
 bin/start-hubble.sh
 ```
 
-启动完成后访问 `http://<host>:8088`。停止服务时执行 `bin/stop-hubble.sh`。
+`start-hubble.sh` 支持以下参数：
+
+| 参数 | 说明 |
+|------|------|
+| `-f`、`--foreground [true\|false]` | 前台运行而不是以守护进程方式运行，Docker 镜像使用 `-f` |
+| `-d`、`--debug` | 在 `8787` 端口开启 JDWP 调试（`server=y,suspend=n`） |
+
+脚本以 `-Xms512m -Dfile.encoding=UTF-8 -Dhubble.home.path=<安装目录>` 启动 JVM，把 PID 写入 `bin/pid`，日志输出到 `logs/hugegraph-hubble.log`，并最多等待 30 秒直到 `http://<server.host>:<server.port>/about` 有响应后才返回。
+
+打包默认值为 `server.host=localhost`，即在修改之前只接受本机回环访问。启动完成后访问 `http://<host>:8088`。
+
+停止服务时执行 `bin/stop-hubble.sh`：它先发送 `SIGTERM`，让关闭钩子暂停正在运行的导入任务并干净地关闭内置 H2 数据库；只有在 `STOP_TIMEOUT` 秒（环境变量，默认 `30`）后进程仍然存活时，才会升级为 `SIGKILL`。
 
 #### 2.3 源码编译
 
-Hubble 的构建由 `hugegraph-hubble/hubble-dist/pom.xml` 中的 `frontend-maven-plugin` 安装 Node.js 18.20.8 和 Yarn 1.22.21，无需预先安装这两个工具。
+Hubble 的构建由 `hugegraph-hubble/hubble-dist/pom.xml` 中的 `frontend-maven-plugin` 安装 Node.js v18.20.8 和 Yarn v1.22.21，无需预先安装这两个工具。此外需要 JDK 11 和 Maven。
 
 下载 toolchain 源码包
 
@@ -128,10 +182,12 @@ cd apache-hugegraph-hubble-*
 bin/start-hubble.sh -d
 ```
 
+前端开发时可在 `hubble-fe` 目录下执行 `yarn dev`。后端 POM 未配置 `spring-boot:run`，请改为从 `hubble-be/target/classes` 启动 `org.apache.hugegraph.HugeGraphHubble`，并用 `-Dhubble.home.path` 指向一个可写目录。
+
 
 ### 3	平台使用流程
 
-平台的模块使用流程如下：
+首页把各模块归纳为三条主线：图概览、图导入和图查询，同时显示当前运行在 PD / 集群模式还是 non-PD 单机模式。平台的模块使用流程如下：
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/2平台使用流程.png" alt="image">
@@ -140,8 +196,10 @@ bin/start-hubble.sh -d
 
 ### 4	平台使用说明
 #### 4.1	图管理
+在 PD 模式下，【图空间管理】列出集群中的所有图空间，并可创建或编辑图空间，包括别名、可选的 Kubernetes 命名空间与计算任务，以及资源上限。在 non-PD 单机模式下只有一个名为 `DEFAULT` 的图空间，图空间列表会被跳过。
+
 ##### 4.1.1	图创建
-图管理模块下，点击【创建图】，通过填写图 ID、图名称、主机名、端口号、用户名、密码的信息，实现多图的连接。
+图管理模块下，点击【新建图】，填写图名称、可选的别名、可选的 Schema 模板和示例数据。图名称在其所属图空间内唯一，创建后不可修改。
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/311图创建.png" alt="image">
@@ -154,10 +212,10 @@ bin/start-hubble.sh -d
   <img src="/docs/images/images-hubble/311图创建2.png" alt="image">
 </div>
 
-> **注意**：如果使用 docker 启动 `hubble`，且 `server` 和 `hubble` 位于同一宿主机，不能直接使用 `localhost/127.0.0.1` 作为主机名。如果 `hubble` 和 `server` 在同一 docker 网络下，则可以直接使用 container_name 作为主机名，端口则为 8080。或者也可以使用宿主机 ip 作为主机名，此时端口为宿主机为 server 配置的端口
+> **注意**：Server 连接不在此页面配置，而是来自 `conf/hugegraph-hubble.properties`，通过 `server.direct_url` 或 PD 发现获得，Docker 下的主机名规则见 2.1 节。只有当所连接的 Server 提供建图能力（REST API 0.67 及以上）时才会显示新建图入口，旧版 Server 上图列表为只读。
 
 ##### 4.1.2	图访问
-实现图空间的信息访问，进入后，可进行图的多维查询分析、元数据管理、数据导入、算法分析等操作。
+实现图空间的信息访问，进入后，可进行图的多维查询分析、元数据管理、数据导入、算法分析等操作。【进入图分析平台】打开查询工作台，【元数据配置】打开 Schema 页面，图详情页展示顶点/边统计信息和 Schema。
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/312图访问.png" alt="image">
@@ -165,8 +223,9 @@ bin/start-hubble.sh -d
 
 
 ##### 4.1.3	图管理
-1. 用户通过对图的概览、搜索以及单图的信息编辑与删除，实现图的统一管理。
-2. 搜索范围：可对图名称和 ID 进行搜索。
+1. 图列表提供卡片视图和列表视图，搜索按图名称匹配。
+2. 单图操作包括：查看 schema（可【导出 Groovy Schema】）、元数据配置、克隆图（仅 Schema，或 Schema 与数据）、清空 Schema 与数据、删除，以及 PD 模式下的设为默认。
+3. 【示例数据与资源】可在当前图中构建 Demo 图：红楼梦 Demo 图、人物与软件 Demo 图、迷你电影 Rank Demo。这些 Demo 只补齐缺失的 Schema 和元素，不会清空已有数据。
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/313图管理.png" alt="image">
@@ -175,7 +234,7 @@ bin/start-hubble.sh -d
 
 #### 4.2	元数据建模（列表 + 图模式）
 ##### 4.2.1	模块入口
-左侧导航处：
+从图列表进入【元数据配置】，或直接访问图的元数据页面 `/graphspace/<graphspace>/graph/<graph>/meta`。页面包含属性、顶点类型、边类型、顶点索引、边索引五个标签页，并可在列表视图和图视图之间切换。
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/321元数据入口.png" alt="image">
@@ -201,26 +260,9 @@ bin/start-hubble.sh -d
 </div>
 
 
-###### 4.2.2.2	复用
-1.	平台提供【复用】功能，可直接复用其他图的元数据。
-2.  选择需要复用的图 ID，继续选择需要复用的属性，之后平台会进行是否冲突的校验，通过后，可实现元数据的复用。
-
-选择复用项：
-
-<div style="text-align: center;">
-  <img src="/docs/images/images-hubble/3222属性复用.png" alt="image">
-</div>
-
-
-校验复用项：
-
-<div style="text-align: center;">
-  <img src="/docs/images/images-hubble/3222属性复用2.png" alt="image">
-</div>
-
-
-###### 4.2.2.3	管理
-1.	在属性列表中可进行单条删除或批量删除操作。
+###### 4.2.2.2	管理
+1.	在属性列表中可进行单条删除或批量删除操作，已被顶点类型或边类型使用的属性无法删除。
+2.	删除元数据会以异步任务方式执行，可在异步任务中查看进度。
 
 ##### 4.2.3	顶点类型
 ###### 4.2.3.1	创建
@@ -240,12 +282,8 @@ bin/start-hubble.sh -d
 </center>
 
 
-###### 4.2.3.2	复用
-1.	顶点类型的复用，会将此类型关联的属性和属性索引一并复用。
-2.	复用功能使用方法类似属性的复用，见 3.2.2.2。
-
-###### 4.2.3.3	管理
-1.	可进行编辑操作，顶点样式、关联类型、顶点展示内容、属性索引可编辑，其余不可编辑。
+###### 4.2.3.2	管理
+1.	可进行编辑操作，顶点样式、关联属性、顶点展示内容、属性索引可编辑，其余不可编辑。图模式下双击顶点类型即可编辑。
 
 
 2.	可进行单条删除或批量删除操作。
@@ -257,7 +295,7 @@ bin/start-hubble.sh -d
 
 ##### 4.2.4	边类型
 ###### 4.2.4.1	创建
-1.	填写或选择边类型名称、起点类型、终点类型、关联属性、是否允许多次连接、边样式、查询结果中边下方展示的内容，以及索引的信息：包括是否创建类型索引，及属性索引的具体内容，完成边类型的创建。
+1.	填写或选择边类型名称、类型（普通类型、父边类型或子边类型，用于边类型的层级关系）、起点类型、终点类型、关联属性、是否允许多次连接、边样式、查询结果中边下方展示的内容，以及索引的信息：包括是否创建类型索引，及属性索引的具体内容，完成边类型的创建。
 
 列表模式：
 
@@ -273,17 +311,15 @@ bin/start-hubble.sh -d
 </center>
 
 
-###### 4.2.4.2	复用
-1.	边类型的复用，会将此类型的起点类型、终点类型、关联的属性和属性索引一并复用。
-2.	复用功能使用方法类似属性的复用，见 3.2.2.2。
-
-
-###### 4.2.4.3	管理
+###### 4.2.4.2	管理
 1.	可进行编辑操作，边样式、关联属性、边展示内容、属性索引可编辑，其余不可编辑，同顶点类型。
 2.	可进行单条删除或批量删除操作。
 
 ##### 4.2.5	索引类型
-展示顶点类型和边类型的顶点索引和边索引。
+展示顶点类型和边类型的顶点索引和边索引，支持二级索引、范围索引、全文索引和唯一索引。
+
+##### 4.2.6	Schema 模板
+【Schema 模板】（`/graphspace/<graphspace>/schema`）按图空间维护一份可复用的模板库。示例模板由 Hubble 内置，可以使用、移除和恢复，在保存之前不会写入 Server；用户模板以 Groovy Schema 形式保存在 Server 上，可以创建、编辑和删除。创建图时可以选择已有模板，使其 Schema 立即生效。
 
 #### 4.3	数据导入
 
@@ -297,41 +333,43 @@ bin/start-hubble.sh -d
 
 
 ##### 4.3.1	模块入口
-左侧导航处：
+左侧导航「图导入」下的【数据源管理】和【数据导入】：
 <center>
   <img src="/docs/images/images-hubble/331导入入口.png" alt="image">
 </center>
 
 
-##### 4.3.2	创建任务
-1.	填写任务名称和备注（非必填），可以创建导入任务。
-2.	可创建多个导入任务，并行导入。
-
-<center>
-  <img src="/docs/images/images-hubble/332创建任务.png" alt="image">
-</center>
-
-
-##### 4.3.3	上传文件
-1.	上传需要构图的文件，目前支持的格式为 CSV，后续会不断更新。
-2.	可同时上传多个文件。
+##### 4.3.2	数据源
+1.	【数据源管理】用于登记导入任务的读取来源，支持四种类型：FILE（本地上传）、HDFS、Kafka 和 JDBC。
+2.	FILE 类型需要上传需要构图的文件，可接受的格式由 `upload_file.format_list` 决定，默认为 `csv` 和 `txt`。
+3.	单文件与总大小上限默认分别为 1 GB 和 10 GB，未完成的上传分片会在 `upload_file.max_uploading_time`（默认 12 小时）后被清理。
 
 <center>
   <img src="/docs/images/images-hubble/333上传文件.png" alt="image">
 </center>
 
 
+##### 4.3.3	创建任务
+1.	【数据导入】>【创建任务】分四步配置：输入基础信息、选择源端字段、选择映射字段、输入调度信息。
+2.	基础信息包括任务名称（1 到 48 个中文、字母、数字或 `_`）、目标图空间与图、源端类型和数据源。
+3.	可创建多个导入任务，并行导入。
+
+<center>
+  <img src="/docs/images/images-hubble/332创建任务.png" alt="image">
+</center>
+
+
 ##### 4.3.4	设置数据映射
-1. 对上传的文件分别设置数据映射，包括文件设置和类型设置
-2. 文件设置：勾选或填写是否包含表头、分隔符、编码格式等文件本身的设置内容，均设置默认值，无需手动填写
+1. 对选定的数据源设置数据映射，包括文件设置和类型设置
+2. 文件设置：勾选或填写是否包含表头、分隔符、编码格式等源端本身的设置内容，均设置默认值，无需手动填写
 3. 类型设置：
 
     1.	顶点映射和边映射：
 
-       【顶点类型】 ：选择顶点类型，并为其 ID 映射上传文件中列数据；
+       【顶点类型】 ：选择顶点类型，并为其 ID 映射源端中的列数据；
 
-       【边类型】：选择边类型，为其起点类型和终点类型的 ID 列映射上传文件的列数据；
-    2.	映射设置：为选定的顶点类型的属性映射上传文件中的列数据，此处，若属性名称与文件的表头名称一致，可自动匹配映射属性，无需手动填选
+       【边类型】：选择边类型，为其起点类型和终点类型的 ID 列映射源端的列数据；
+    2.	映射设置：为选定的顶点类型的属性映射源端中的列数据，此处，若属性名称与文件的表头名称一致，可自动匹配映射属性，无需手动填选
     3.	完成设置后，显示设置列表，方可进行下一步操作，支持映射的新增、编辑、删除操作
 
 设置映射的填写内容：
@@ -349,7 +387,7 @@ bin/start-hubble.sh -d
 
 
 ##### 4.3.5	导入数据
-导入前需要填写导入设置参数，填写完成后，可开始向图库中导入数据
+最后一步选择任务的执行方式：执行一次表示一次性导入，周期执行使用 Quartz cron 表达式（例如 `0 0/5 * * * ?`），实时执行用于 Kafka 数据源。
 1.	导入设置
 - 导入设置参数项如下图所示，均设置默认值，无需手动填写
 
@@ -359,8 +397,8 @@ bin/start-hubble.sh -d
 
 
 2.	导入详情
-- 点击开始导入，开始文件的导入任务
-- 导入详情中提供每个上传文件设置的映射类型、导入速度、导入的进度、耗时以及当前任务的具体状态，并可对每个任务进行暂停、继续、停止等操作
+- 在任务列表中运行任务即可开始导入，也可在同一列表中暂停、编辑或删除任务
+- 任务的执行历史提供每次执行的执行实例 ID、导入记录数、平均速率（条/秒）、导入耗时和状态
 - 若导入失败，可查看具体原因
 
 <center>
@@ -368,29 +406,31 @@ bin/start-hubble.sh -d
 </center>
 
 
-#### 4.4	数据分析
+#### 4.4	图查询
 ##### 4.4.1	模块入口
-左侧导航处：
+左侧导航「图查询」下的【GQL 图遍历】：
 <center>
   <img src="/docs/images/images-hubble/341分析入口.png" alt="image">
 </center>
 
 
 ##### 4.4.2	多图切换
-通过左侧切换入口，灵活切换多图的操作空间
+顶部栏承载当前图空间和图，可在不离开页面的情况下灵活切换多图的操作空间
 <center>
   <img src="/docs/images/images-hubble/342多图切换.png" alt="image">
 </center>
 
 
 ##### 4.4.3	图分析与处理
-HugeGraph 支持 Apache TinkerPop3 的图遍历查询语言 Gremlin，Gremlin 是一种通用的图数据库查询语言，通过输入 Gremlin 语句，点击执行，即可执行图数据的查询分析操作，并可实现顶点/边的创建及删除、顶点/边的属性修改等。
+HugeGraph 支持 Apache TinkerPop3 的图遍历查询语言 Gremlin，Gremlin 是一种通用的图数据库查询语言，通过输入 Gremlin 语句，点击执行，即可执行图数据的查询分析操作，并可实现顶点/边的创建及删除、顶点/边的属性修改等。当所连接的 Server 支持 Cypher 时，Gremlin 旁边会出现 Cypher 页签。Text2GQL 页签仅为界面预览，并未接入任何模型或查询服务，其中输入的内容不会被发送或执行。
 
-Gremlin 查询后，下方为图结果展示区域，提供 3 种图结果展示方式，分别为：【图模式】、【表格模式】、【Json 模式】。
+每条语句可以按两种模式执行：立即查询直接返回结果，适合 30 秒内可完成的小规模分析；异步执行则提交一个任务，进度和结果在异步任务中查看。`Ctrl`/`Command` + `Enter` 可执行当前语句。
+
+查询后，下方为图结果展示区域，提供 3 种图结果展示方式，分别为：【图模式】、【表格模式】、【Json 模式】。图画布支持 2D 与 3D 渲染。
 
 > ⚠️ **SEC 提醒**：Hubble 允许在网页端直接输入并执行 Gremlin 原生查询语句，这赋予了使用者较高的操作权限。**请避免将 Hubble 服务暴露在公网环境**，建议在使用时确保图数据库服务端已开启 **[鉴权体系 (Auth)](/cn/docs/config/config-authentication/)** 并配合 **IP 白名单**进行严格的权限控制，防止未授权访问或恶意代码执行风险。
 
-支持缩放、居中、全屏、导出等操作。
+支持缩放、居中、全屏、布局与样式配置、图例、缩略图、撤销与重做、导出等操作。画布可导出为 JSON、CSV 或图片，导出的画布也可以再次导入。
 
 【图模式】
 
@@ -465,24 +505,28 @@ Gremlin 查询后，下方为图结果展示区域，提供 3 种图结果展示
 </center>
 
 
-#### 4.5	任务管理
+#### 4.5	异步任务
 ##### 4.5.1	模块入口
-左侧导航处：
+左侧导航「图查询」下的【异步任务】：
 <center>
   <img src="/docs/images/images-hubble/351任务管理入口.png" alt="image">
 </center>
 
 
 ##### 4.5.2	任务管理
-1.  提供异步任务的统一的管理与结果查看，异步任务包括 4 类，分别为：
--   gremlin：Gremlin 任务务
--   algorithm：OLAP 算法任务务
+1.  提供异步任务的统一的管理与结果查看，任务类型包括：
+-   gremlin：Gremlin 任务
+-   cypher：Cypher 任务
+-   computer-dis：算法任务
 - 	remove_schema：删除元数据
+- 	create_index：创建索引
 - 	rebuild_index：重建索引
-2.	列表显示当前图的异步任务信息，包括：任务 ID，任务名称，任务类型，创建时间，耗时，状态，操作，实现对异步任务的管理。
+- 	vermeer-task:load：Vermeer 图加载任务
+- 	vermeer-task:compute：Vermeer 图计算任务
+2.	列表显示当前图的异步任务信息，包括：任务 ID，任务名称，任务类型，创建时间，耗时，状态，操作，实现对异步任务的管理。列表每 5 秒自动刷新一次。
 3.	支持对任务类型和状态进行筛选
 4.	支持搜索任务 ID 和任务名称
-5.	可对异步任务进行删除或批量删除操作
+5.	运行中的任务可以取消，异步任务可进行删除或批量删除操作
 
 <center>
   <img src="/docs/images/images-hubble/352任务列表.png" alt="image">
@@ -492,7 +536,7 @@ Gremlin 查询后，下方为图结果展示区域，提供 3 种图结果展示
 ##### 4.5.3	Gremlin 异步任务
 1.创建任务
 
-- 数据分析模块，目前支持两种 Gremlin 操作，Gremlin 查询和 Gremlin 任务；若用户切换到 Gremlin 任务，点击执行后，在异步任务中心会建立一条异步任务；
+- 图查询模块支持两种执行方式：立即查询和异步任务；若用户切换到异步方式，点击执行后，在异步任务中心会建立一条异步任务；Cypher 语句同理会建立一条 Cypher 任务；
 2.任务提交
 - 任务提交成功后，图区部分返回提交结果和任务 ID
 3.任务详情
@@ -511,11 +555,11 @@ Gremlin 查询后，下方为图结果展示区域，提供 3 种图结果展示
 
 
 4.查看结果
-- 结果通过 json 形式展示
+- 结果通过 json 形式展示，较长的结果可以就地展开
 
 
-##### 4.5.4	OLAP 算法任务
-Hubble 上暂未提供可视化的 OLAP 算法执行，可调用 RESTful API 进行 OLAP 类算法任务，在任务管理中通过 ID 找到相应任务，查看进度与结果等。
+##### 4.5.4	算法任务
+从【内置图算法】提交的批量算法会在这里以算法任务的形式出现，Vermeer 的图加载与图计算任务同理。可在列表中通过 ID 找到相应任务，打开后查看进度与结果等。算法表单本身见 4.6 节。
 
 ##### 4.5.5	删除元数据、重建索引
 1.创建任务
@@ -541,16 +585,42 @@ Hubble 上暂未提供可视化的 OLAP 算法执行，可调用 RESTful API 进
 </center>
 
 
+#### 4.6	内置图算法
+
+「图查询」下的【内置图算法】为 Server 提供的算法给出参数表单，并按用途分组：探索邻居、寻找路径与连接、比较与排序、度量重要性、发现社区、分析图结构。每个算法都提供指向官方 API 文档的链接。
+
+支持两种执行方式：
+
+- 交互式探索调用 Server 的 OLTP traverser 接口并直接返回结果，覆盖 K-out 与 K-neighbor，单源、带权和多点形式的最短路径，路径与全部路径，定制化路径与模板路径，环与射线，交点与定制化交点，共同邻居，Jaccard 相似度，Fusiform 相似度，Adamic-Adar，资源分配，Egonet，以及 rank 与 neighbor rank 接口。
+- 集群批量计算提交一个覆盖全图的异步任务，结果在异步任务中查看，覆盖 PageRank 与个性化 PageRank，度中心性、接近中心性与介数中心性，K-core，弱连通分量，标签传播，Louvain，三角形计数，聚类系数，环检测，子图匹配与 Links；在提供 Vermeer 的部署中还有对应的 Vermeer 版本。
+
+批量算法需要 HugeGraph Computer 环境，部署要求时还包括 Kubernetes。当无法访问 Computer 时，页面会直接提示而不会提交任务。
+
+#### 4.7	登录与账号管理
+
+当所连接的 Server 开启了鉴权时，Hubble 会打开 `/login` 登录页。请使用 HugeGraph Server 账号登录：Hubble 会把凭据转发给 Server，并在浏览器会话中保存返回的 token，自身不存储任何账号。登录尝试受限流保护，同一账号与地址连续失败三次之后，后续尝试会开始退避，初始 5 秒并逐次翻倍，最长 600 秒。当 Server 允许匿名访问时，`/login` 会重定向到首页，个人中心和账号管理页面也会隐藏。
+
+【个人中心】展示账号信息并可修改密码。【账号管理】面向具备账号管理或图空间成员管理能力的账号，可创建账号并分配四种权限预设之一：超级管理员、GraphSpace 只读、GraphSpace 读写、GraphSpace 管理员。界面上不再暴露底层的 role、target、access、belong 记录。
+
+#### 4.8	集群运维
+
+在 PD 模式下，【系统与运维】会为具备相应能力的账号提供【集群概览】和【节点详情】。集群概览展示拓扑、各层级的节点状态，以及在线 Store 数、PD Leader、容量、数据量、图数、分区数、副本数等集群概况。节点详情列出所有发现到的节点，支持按类型和状态筛选，并可打开单个节点查看指标、Leader 角色和 Raft 分片。节点详情在单机模式下同样可用，集群概览则需要 PD。
+
+导航页还可以通过 `dashboard.address` 链接一个可选的外部监控面板。它是独立的监控入口，不配置也不会影响集群概览和节点详情。
+
 ### 5 配置说明
 
 HugeGraph-Hubble 可以通过 `conf/hugegraph-hubble.properties` 文件进行配置。
 
-#### 5.1 服务器配置
+#### 5.1 服务配置
 
 | 配置项 | 默认值 | 说明 |
 |--------|--------|------|
-| `hubble.host` | `0.0.0.0` | Hubble 服务绑定的地址 |
-| `hubble.port` | `8088` | Hubble 服务监听的端口 |
+| `server.host` | `localhost` | Hubble 服务绑定的地址，Docker 镜像会改写为 `0.0.0.0` |
+| `server.port` | `8088` | Hubble 服务监听的端口 |
+| `server.protocol` | `http` | 访问 HugeGraphServer 使用的协议，可选 `http` 或 `https` |
+| `ssl.client_truststore_file` | `conf/hugegraph.truststore` | 客户端 truststore 路径，`server.protocol=https` 时使用 |
+| `ssl.client_truststore_password` | `hugegraph` | 客户端 truststore 密码，`server.protocol=https` 时使用 |
 
 #### 5.2 Server 与 PD
 
@@ -560,7 +630,10 @@ HugeGraph-Hubble 可以通过 `conf/hugegraph-hubble.properties` 文件进行配
 | `server.direct_url` | `http://127.0.0.1:8080` | `pd.enabled=false` 时连接的 Server 地址 |
 | `pd.peers` | `127.0.0.1:8686` | PD 节点地址 |
 | `pd.server` | `127.0.0.1:8620` | PD 服务地址 |
+| `cluster` | `hg` | Hubble 连接的集群名称 |
 | `route.type` | `NODE_PORT` | 服务路由方式，可选 `NODE_PORT`、`DDS` 或 `BOTH` |
+| `client.request_timeout` | `60` | HugeGraph 客户端请求超时时间（秒） |
+| `client.url_cache_max_entries` | `1024` | 保留用于回退的已发现 URL 数量上限 |
 
 #### 5.3 Gremlin 查询限制
 
@@ -572,3 +645,36 @@ HugeGraph-Hubble 可以通过 `conf/hugegraph-hubble.properties` 文件进行配
 | `gremlin.vertex_degree_limit` | `100` | 显示的最大顶点度数 |
 | `gremlin.edges_total_limit` | `500` | 返回的最大边数 |
 | `gremlin.batch_query_ids` | `100` | ID 批量查询大小 |
+| `execute-history.show_limit` | `500` | 展示的执行记录条数上限 |
+
+#### 5.4 文件上传
+
+以下配置项不在打包的配置文件中，如需覆盖默认值请自行添加。
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `upload_file.location` | `upload-files` | 存放上传文件的目录 |
+| `upload_file.format_list` | `csv,txt` | 允许上传的文件格式 |
+| `upload_file.single_file_size_limit` | 1 GB | 单个上传文件的大小上限 |
+| `upload_file.total_file_size_limit` | 10 GB | 上传文件的总大小上限 |
+| `upload_file.max_uploading_time` | `43200` | 超过该秒数后清理未完成的上传分片 |
+
+#### 5.5 集群运维
+
+以下配置项用于集群概览和节点详情页面。
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `operations.connect_timeout_ms` | `1500` | 每个运维上游的连接超时 |
+| `operations.read_timeout_ms` | `2500` | 每个运维上游的读取超时 |
+| `operations.max_response_bytes` | `1048576` | 接受的运维上游响应体大小上限 |
+| `operations.cache_ttl_seconds` | `5` | 运维快照缓存的有效期 |
+| `operations.cache_max_entries` | `1024` | 跨凭据保留的运维快照数量 |
+| `operations.store_threads` | `16` | Store 指标采集的并发任务数 |
+| `operations.store_deadline_ms` | `5000` | 一轮 Store 指标采集的截止时间 |
+| `operations.store.allowed_targets` | `[http://127.0.0.1:8520,http://[::1]:8520]` | Hubble 允许访问的 Store 指标来源（精确匹配） |
+| `operations.pd.username` / `operations.pd.password` | `hubble` / 空 | 仅后端使用的 PD 服务身份 |
+| `operations.store.username` / `operations.store.password` | `hubble` / 空 | 仅后端使用的 Store 服务身份 |
+| `dashboard.address` | `127.0.0.1:8092` | 可选的外部监控面板地址，留空则隐藏入口 |
+
+> `operations.store.allowed_targets` 的默认值仅适用于本地测试。生产部署必须显式列出每一个受信任的 Store 协议、主机和端口，服务发现不会向该白名单追加来源。HTTPS 来源会保留其配置的主机名用于 TLS SNI 与证书校验。PD 和 Store 的密码请通过受保护的部署配置提供，不要写入打包的配置文件。

--- a/content/en/docs/quickstart/toolchain/hugegraph-hubble.md
+++ b/content/en/docs/quickstart/toolchain/hugegraph-hubble.md
@@ -6,36 +6,57 @@ weight: 1
 
 ### 1 HugeGraph-Hubble Overview
 
-> ⚠️ **Security notice**: As of the 1.7.0 release, Hubble does not provide Auth/Login protection. This feature is planned for the 1.8.0 release. Do not expose Hubble to the public Internet or untrusted networks; restrict access with IP/port allowlists and HTTPS.
+> ⚠️ **Security notice**: Hubble listens on plain HTTP. Do not expose it to the public Internet or untrusted networks; terminate HTTPS in front of it and restrict access with IP/port allowlists. Hubble keeps no account database of its own: when the connected HugeGraph Server has authentication enabled, Hubble shows a sign-in page and forwards the credentials to the Server; when the Server allows anonymous access, there is no sign-in and the account pages are hidden.
+
+> **Version note**: This page follows hugegraph-toolchain `master`. Features that depend on newer Server, PD or Store versions are marked below and are unavailable on older Servers.
 
 > **Testing Guide**: For running HugeGraph-Hubble tests locally, please refer to [HugeGraph Toolchain Local Testing Guide](/docs/guides/toolchain-local-test)
 
-HugeGraph-Hubble is HugeGraph's web management interface. It manages graph connections and schemas, imports data, runs Gremlin queries, and visualizes query results.
+HugeGraph-Hubble is HugeGraph's web management interface. It connects to one HugeGraph Server, either directly or through PD in a distributed cluster, manages GraphSpaces, graphs and schemas, imports data, runs Gremlin and Cypher queries and built-in graph algorithms, and visualizes the results.
 
 The platform mainly includes the following modules:
 
-##### Graph Management
+##### Graph Overview
 
-Graph Management creates and maintains connections, switches between graphs, and provides access, editing, deletion, and query operations.
+Graph Overview lists GraphSpaces (in PD mode) and graphs. It creates, clones and clears graphs, loads demo graphs, opens the graph detail page with statistics and schema, and jumps to the query workbench.
 
 ##### Metadata Modeling
 
-Metadata Modeling manages PropertyKeys, VertexLabels, EdgeLabels, and IndexLabels. It provides list and graph views and supports reusing metadata across graphs.
-
-##### Graph Analysis
-
-Graph Analysis runs Gremlin and path queries and displays results as a graph, table, or JSON. It also keeps execution history and saved statements, and exports query results as JSON.
-
-##### Task Management
-
-Task Management displays background tasks such as asynchronous Gremlin jobs and index creation or rebuilding.
+Metadata Modeling manages PropertyKeys, VertexLabels, EdgeLabels and IndexLabels of one graph, in list and graph views. Schema Templates keep reusable Groovy schemas per GraphSpace that can be applied when a graph is created.
 
 ##### Data Import
 
 > The data import page is intended for small-scale trials. For bulk or production imports, use [HugeGraph Loader](/docs/quickstart/toolchain/hugegraph-loader).
 
-The data import page guides you through creating a task, uploading files, and mapping fields. Multiple import tasks can run in parallel, with resumable uploads and error retries.
+Data Sources register FILE, HDFS, JDBC and KAFKA sources. Import tasks are configured in four steps and can run once, on a cron schedule, or continuously for Kafka.
 
+##### Graph Query
+
+Graph Query runs Gremlin and Cypher statements in immediate or asynchronous mode and displays results as a graph (2D or 3D), a table, or JSON. It keeps execution records and favorite statements.
+
+##### Built-in Graph Algorithms
+
+Built-in Graph Algorithms provides forms for the Server's OLTP traverser APIs (interactive exploration) and for OLAP jobs (cluster batch computation through HugeGraph Computer or Vermeer).
+
+##### Async Tasks
+
+Async Tasks lists background tasks such as Gremlin and Cypher tasks, algorithm tasks, metadata removal, index creation and rebuild, and Vermeer load or compute tasks, with detail, cancel and delete actions.
+
+##### System and Operations
+
+System and Operations covers the personal profile, account management with GraphSpace permission presets, and, in PD mode, the cluster overview and node details.
+
+#### 1.1 Compatibility
+
+Hubble detects the authentication mode and the capabilities of the connected Server; there is no separate authentication switch in Hubble. The supported combinations are:
+
+| HugeGraph Server / PD | Deployment | Hubble compatibility | Scope and limitations |
+|---|---|---|---|
+| Server 1.5.x | Standalone, normally without authentication | Minimum compatibility | Basic graph, schema, data and Gremlin workflows only. GraphSpace, account permissions, PD/Store topology, cluster operations and newer algorithms are unavailable. |
+| Server 1.7.x with matching PD/Store 1.7.x | Standalone or distributed | Minimum compatibility through legacy adapters | Core management and query workflows stay usable, but legacy REST/Gremlin authentication, permission semantics, metrics and algorithm capabilities give a reduced experience. |
+| Server, PD and Store 1.8.x or later | Distributed deployment recommended | Full and recommended experience | GraphSpace, account permission presets, cluster operations, async tasks and algorithm capability handling are designed and validated against this generation. |
+
+Use matching Server, PD and Store minor versions in a distributed cluster.
 
 ### 2 Deploy
 
@@ -45,23 +66,42 @@ There are three ways to deploy `hugegraph-hubble`
 - Download the Toolchain binary package
 - Source code compilation
 
+Hubble runs on Java 11: the backend is compiled with `java.version=11` and the Docker image is based on `eclipse-temurin:11-jre`. `bin/start-hubble.sh` only checks that a `java` binary is on the `PATH`, so make sure the right JDK is selected.
+
 #### 2.1 Use docker (Convenient for Test/Dev)
 
-> **Special Note**: If you are starting `hubble` with Docker, and `hubble` and the server are on the same host. When configuring the hostname for the graph on the Hubble web page, please do not directly set it to `localhost/127.0.0.1`. This will refer to the `hubble` container internally rather than the host machine, resulting in a connection failure to the server.
+> **Special Note**: Hubble no longer asks for the Server host and port on the web page. The Server address comes from `conf/hugegraph-hubble.properties`: `server.direct_url` when `pd.enabled=false`, or PD discovery through `pd.peers` when `pd.enabled=true`. Inside the container `127.0.0.1` refers to the `hubble` container itself, so the packaged default `server.direct_url=http://127.0.0.1:8080` does not reach a Server running in another container.
 >
->  If `hubble` and `server` is in the same docker network, we **recommend** using the `container_name` (in our example, it is `server`) as the hostname, and `8080` as the port. Or you can use the **host IP** as the hostname, and the port is configured by the host for the server.
+> If `hubble` and `server` are in the same docker network, we **recommend** using the `container_name` (in our example, it is `server`) as the hostname, and `8080` as the port. Or you can use the **host IP** as the hostname, and the port is configured by the host for the server.
 
-We can use `docker run -itd --name=hubble -p 8088:8088 hugegraph/hubble:1.5.0` to quick start [hubble](https://hub.docker.com/r/hugegraph/hubble).
+The image copies the packaged distribution to `/hubble`, rewrites `server.host=0.0.0.0` and clears `dashboard.address` in `/hubble/conf/hugegraph-hubble.properties`, exposes port `8088` and runs `./bin/start-hubble.sh -f` in the foreground.
+
+Prepare a `hugegraph-hubble.properties` that points at your Server and keeps the container listening on all interfaces:
+
+```properties
+server.host=0.0.0.0
+server.port=8088
+pd.enabled=false
+server.direct_url=http://server:8080
+```
+
+Then start [hubble](https://hub.docker.com/r/hugegraph/hubble) with that file mounted over the packaged configuration:
+
+```bash
+docker run -itd --name=hubble -p 8088:8088 \
+  -v "$PWD/hugegraph-hubble.properties:/hubble/conf/hugegraph-hubble.properties" \
+  hugegraph/hubble:1.7.0
+```
 
 Alternatively, you can use Docker Compose to start `hubble`. Additionally, if `hubble` and the graph is in the same Docker network, you can access the graph using the container name of the graph, eliminating the need for the host machine's IP address.
 
-Use `docker-compose up -d`，`docker-compose.yml` is following:
+Use `docker-compose up -d`, `docker-compose.yml` is following:
 
 ```yaml
 version: '3'
 services:
   server:
-    image: hugegraph/hugegraph:1.5.0
+    image: hugegraph/hugegraph:1.7.0
     container_name: server
     environment:
       - PASSWORD=xxx
@@ -69,17 +109,19 @@ services:
       - 8080:8080
 
   hubble:
-    image: hugegraph/hubble:1.5.0
+    image: hugegraph/hubble:1.7.0
     container_name: hubble
     ports:
       - 8088:8088
+    volumes:
+      - ./hugegraph-hubble.properties:/hubble/conf/hugegraph-hubble.properties
 ```
 
-> Note: 
+> Note:
 >
 > 1. The docker image of hugegraph-hubble is a convenience release to start hugegraph-hubble quickly, but not **official distribution** artifacts. You can find more details from [ASF Release Distribution Policy](https://infra.apache.org/release-distribution.html#dockerhub).
-> 
-> 2. Recommend to use `release tag`(like `1.5.0`) for the stable version. Use `latest` tag to experience the newest functions in development.
+>
+> 2. Recommend to use `release tag` (like `1.7.0`) for the stable version. Use `latest` tag to experience the newest functions in development.
 
 #### 2.2 Download the Toolchain binary package
 
@@ -93,17 +135,28 @@ tar -xvf "${ARCHIVE}.tar.gz"
 cd "${ARCHIVE}/apache-hugegraph-hubble-incubating-${VERSION}"
 ```
 
-Run `hubble`
+Edit `conf/hugegraph-hubble.properties` so that the Server address is correct, then run `hubble`
 
 ```bash
 bin/start-hubble.sh
 ```
 
-After startup, open `http://<host>:8088`. Run `bin/stop-hubble.sh` to stop the service.
+`start-hubble.sh` accepts the following options:
+
+| Option | Description |
+|--------|-------------|
+| `-f`, `--foreground [true\|false]` | Run in the foreground instead of as a daemon; the Docker image uses `-f` |
+| `-d`, `--debug` | Enable the JDWP debugger on port `8787` (`server=y,suspend=n`) |
+
+The script starts the JVM with `-Xms512m -Dfile.encoding=UTF-8 -Dhubble.home.path=<install dir>`, writes the PID to `bin/pid`, logs to `logs/hugegraph-hubble.log` and waits up to 30 seconds for `http://<server.host>:<server.port>/about` to answer before it returns.
+
+The packaged default is `server.host=localhost`, so the service only accepts loopback connections until you change it. After startup, open `http://<host>:8088`.
+
+Run `bin/stop-hubble.sh` to stop the service. It sends `SIGTERM` first so that the shutdown hooks pause running load tasks and close the embedded H2 database cleanly, and only escalates to `SIGKILL` if the process is still alive after `STOP_TIMEOUT` seconds (environment variable, default `30`).
 
 #### 2.3 Source code compilation
 
-Hubble's build uses `frontend-maven-plugin` in `hugegraph-hubble/hubble-dist/pom.xml` to install Node.js 18.20.8 and Yarn 1.22.21, so neither tool needs to be installed beforehand.
+Hubble's build uses `frontend-maven-plugin` in `hugegraph-hubble/hubble-dist/pom.xml` to install Node.js v18.20.8 and Yarn v1.22.21, so neither tool needs to be installed beforehand. JDK 11 and Maven are required.
 
 Download the toolchain source code.
 
@@ -128,9 +181,11 @@ Run `hubble`
 bin/start-hubble.sh -d
 ```
 
+For frontend work, run `yarn dev` inside `hubble-fe`. The backend POM does not configure `spring-boot:run`, so run `org.apache.hugegraph.HugeGraphHubble` from `hubble-be/target/classes` with `-Dhubble.home.path` pointing at a writable directory instead.
+
 ### 3	Platform Workflows
 
-The module usage process of the platform is as follows:
+The home page groups the modules into three journeys: Graph Overview, Graph Import and Graph Query. It also shows whether Hubble runs in PD / cluster mode or in non-PD standalone mode. The module usage process of the platform is as follows:
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/2平台使用流程.png" alt="image">
@@ -139,8 +194,10 @@ The module usage process of the platform is as follows:
 
 ### 4	Platform Instructions
 #### 4.1	Graph Management
+In PD mode, [Graph Space Management] lists all GraphSpaces of the cluster and can create or edit one, including its alias, optional Kubernetes namespace and compute task, and resource limits. In non-PD standalone mode there is exactly one GraphSpace named `DEFAULT` and the GraphSpace list is skipped.
+
 ##### 4.1.1	Graph creation
-Under the graph management module, click [Create graph], and realize the connection of multiple graphs by filling in the graph ID, graph name, host name, port number, username, and password information.
+Under the graph management module, click [New Graph] and fill in the graph name, an optional alias, an optional schema template and optional sample data. The graph name is unique inside its GraphSpace and cannot be changed after creation.
 
 <div style="text-align: center;">
   <img src="/docs/images/images-hubble/311图创建.png" alt="image">
@@ -153,10 +210,10 @@ Create graph by filling in the content as follows:
   <img src="/docs/images/images-hubble/311图创建2.png" alt="image">
 </center>
 
-> **Special Note**: If you are starting `hubble` with Docker, and `hubble` and the server are on the same host. When configuring the hostname for the graph on the Hubble web page, please do not directly set it to `localhost/127.0.0.1`. If `hubble` and `server` is in the same docker network, we **recommend** using the `container_name` (in our example, it is `graph`) as the hostname, and `8080` as the port. Or you can use the **host IP** as the hostname, and the port is configured by the host for the server.
+> **Special Note**: The Server connection is not configured on this page. It comes from `conf/hugegraph-hubble.properties`, through `server.direct_url` or PD discovery; see section 2.1 for the Docker hostname rules. Graph creation is only offered when the connected Server exposes it (REST API 0.67 or later); on older Servers the graph list is read-only.
 
 ##### 4.1.2	Graph Access
-Realize the information access to the graph space. After entering, you can perform operations such as multidimensional query analysis, metadata management, data import, and algorithm analysis of the graph.
+Realize the information access to the graph space. After entering, you can perform operations such as multidimensional query analysis, metadata management, data import, and algorithm analysis of the graph. [Open Graph Studio] opens the query workbench, [Metadata Config] opens the schema pages, and the graph detail page shows vertex and edge statistics together with the schema.
 
 <center>
   <img src="/docs/images/images-hubble/312图访问.png" alt="image">
@@ -164,8 +221,9 @@ Realize the information access to the graph space. After entering, you can perfo
 
 
 ##### 4.1.3	Graph management
-1. Users can achieve unified management of graphs through overview, search, and information editing and deletion of single graphs.
-2. Search range: You can search for the graph name and ID.
+1. The graph list has a card view and a list view. Search matches the graph name.
+2. Per-graph actions are View Schema (with [Export Groovy Schema]), Metadata Config, Clone Graph (schema only, or schema and data), Clear Schema and Data, Delete, and, in PD mode, Set Default.
+3. [Sample data and resources] builds a demo graph inside the current graph: the Red Chamber demo graph, the People & Software demo graph, or the Tiny Movie Rank demo. These demos add missing schema and elements only and never clear existing data.
 
 <center>
   <img src="/docs/images/images-hubble/313图管理.png" alt="image">
@@ -174,7 +232,7 @@ Realize the information access to the graph space. After entering, you can perfo
 
 #### 4.2	Metadata Modeling (list + graph mode)
 ##### 4.2.1	Module entry
-Left navigation:
+Open [Metadata Config] from the graph list, or the metadata page of a graph at `/graphspace/<graphspace>/graph/<graph>/meta`. The page has five tabs, Property, Vertex Type, Edge Type, Vertex Index and Edge Index, and a switch between list view and graph view.
 
 <center>
   <img src="/docs/images/images-hubble/321元数据入口.png" alt="image">
@@ -183,8 +241,8 @@ Left navigation:
 
 ##### 4.2.2	Property type
 ###### 4.2.2.1	Create type
-1. Fill in or select the attribute name, data type, and cardinality to complete the creation of the attribute.
-2. Created attributes can be used as attributes of vertex type and edge type.
+1. Fill in or select the property name, data type, and cardinality to complete the creation of the property.
+2. Created properties can be used as properties of vertex type and edge type.
 
 List mode:
 
@@ -200,30 +258,13 @@ Graph mode:
 </center>
 
 
-###### 4.2.2.2	Reuse
-1. The platform provides the [Reuse] function, which can directly reuse the metadata of other graphs.
-2. Select the graph ID that needs to be reused, and continue to select the attributes that need to be reused. After that, the platform will check whether there is a conflict. After passing, the metadata can be reused.
-
-Select reuse items:
-
-<center>
-  <img src="/docs/images/images-hubble/3222属性复用.png" alt="image">
-</center>
-
-
-Check reuse items:
-
-<center>
-  <img src="/docs/images/images-hubble/3222属性复用2.png" alt="image">
-</center>
-
-
-###### 4.2.2.3	Management
-1. You can delete a single item or delete it in batches in the attribute list.
+###### 4.2.2.2	Management
+1. You can delete a single item or delete it in batches in the property list. A property that is still used by a vertex or edge type cannot be deleted.
+2. Deleting metadata runs as an asynchronous task; check Async Tasks for its progress.
 
 ##### 4.2.3	Vertex type
 ###### 4.2.3.1	Create type
-1. Fill in or select the vertex type name, ID strategy, association attribute, primary key attribute, vertex style, content displayed below the vertex in the query result, and index information: including whether to create a type index, and the specific content of the attribute index, complete the vertex Type creation.
+1. Fill in or select the vertex type name, ID strategy, associated properties, primary key properties, vertex style, content displayed below the vertex in the query result, and index information: including whether to create a type index, and the specific content of the property index, complete the vertex type creation.
 
 List mode:
 
@@ -238,12 +279,8 @@ Graph mode:
   <img src="/docs/images/images-hubble/3231顶点创建2.png" alt="image">
 </center>
 
-###### 4.2.3.2 Reuse
-1. The multiplexing of vertex types will reuse the attributes and attribute indexes associated with this type together.
-2. The reuse method is similar to the property reuse, see 3.2.2.2.
-
-###### 4.2.3.3 Administration
-1. Editing operations are available. The vertex style, association type, vertex display content, and attribute index can be edited, and the rest cannot be edited.
+###### 4.2.3.2 Administration
+1. Editing operations are available. The vertex style, associated properties, vertex display content, and property index can be edited, and the rest cannot be edited. In graph mode, double-click a vertex type to edit it.
 
 2. You can delete a single item or delete it in batches.
 
@@ -254,7 +291,7 @@ Graph mode:
 
 ##### 4.2.4 Edge Types
 ###### 4.2.4.1 Create
-1. Fill in or select the edge type name, start point type, end point type, associated attributes, whether to allow multiple connections, edge style, content displayed below the edge in the query result, and index information: including whether to create a type index, and attribute index The specific content, complete the creation of the edge type.
+1. Fill in or select the edge type name, the type (Normal, Parent or Sub, for edge type hierarchies), start point type, end point type, associated properties, whether to allow multiple connections, edge style, content displayed below the edge in the query result, and index information: including whether to create a type index, and the specific content of the property index, complete the creation of the edge type.
 
 List mode:
 
@@ -270,21 +307,19 @@ Graph mode:
 </center>
 
 
-###### 4.2.4.2 Reuse
-1. The reuse of the edge type will reuse the start point type, end point type, associated attribute and attribute index of this type.
-2. The reuse method is similar to the property reuse, see 3.2.2.2.
-
-
-###### 4.2.4.3 Administration
-1. Editing operations are available. Edge styles, associated attributes, edge display content, and attribute indexes can be edited, and the rest cannot be edited, the same as the vertex type.
+###### 4.2.4.2 Administration
+1. Editing operations are available. Edge styles, associated properties, edge display content, and property indexes can be edited, and the rest cannot be edited, the same as the vertex type.
 2. You can delete a single item or delete it in batches.
 
 ##### 4.2.5 Index Types
-Displays vertex and edge indices for vertex types and edge types.
+Displays vertex and edge indexes for vertex types and edge types. Secondary, range, search and unique indexes are supported.
+
+##### 4.2.6 Schema Templates
+[Schema templates] at `/graphspace/<graphspace>/schema` keeps a reusable template library for the current GraphSpace. Example templates ship with Hubble and can be used, removed or restored; they are not stored on the Server until you save one. User templates hold Groovy schema on the Server and can be created, edited and deleted. When you create a graph, an existing template can be selected so that its schema is applied right away.
 
 #### 4.3 Data Import
 
-> **Note**：currently, we recommend to use [hugegraph-loader](/docs/quickstart/toolchain/hugegraph-loader) to import data formally. The built-in import of `hubble` is used for **testing** and **getting started**.
+> **Note**: currently, we recommend to use [hugegraph-loader](/docs/quickstart/toolchain/hugegraph-loader) to import data formally. The built-in import of `hubble` is used for **testing** and **getting started**.
 
 The usage process of data import is as follows:
 
@@ -294,41 +329,43 @@ The usage process of data import is as follows:
 
 
 ##### 4.3.1	Module entrance
-Left navigation:
+Left navigation, under Graph Import: [Data Sources] and [Data Import].
 <center>
   <img src="/docs/images/images-hubble/331导入入口.png" alt="image">
 </center>
 
 
-##### 4.3.2 Create task
-1. Fill in the task name and remarks (optional) to create an import task.
-2. Multiple import tasks can be created and imported in parallel.
-
-<center>
-  <img src="/docs/images/images-hubble/332创建任务.png" alt="image">
-</center>
-
-
-##### 4.3.3 Uploading files
-1. Upload the file that needs to be composed. The currently supported format is CSV, which will be updated continuously in the future.
-2. Multiple files can be uploaded at the same time.
+##### 4.3.2 Data sources
+1. [Data Sources] registers where an import task reads from. Four source types are supported: FILE (local upload), HDFS, Kafka and JDBC.
+2. For a FILE source, upload the files that need to be composed. The accepted formats come from `upload_file.format_list`, which defaults to `csv` and `txt`.
+3. The single file and total size limits default to 1 GB and 10 GB, and unfinished uploads are discarded after `upload_file.max_uploading_time`, which defaults to 12 hours.
 
 <center>
   <img src="/docs/images/images-hubble/333上传文件.png" alt="image">
 </center>
 
 
+##### 4.3.3 Create task
+1. [Data Import] > [Create Task] configures an import in four steps: Basic Information, Select Source Fields, Select Mapping Fields and Schedule.
+2. Basic Information takes the task name (1 to 48 Chinese characters, letters, digits or `_`), the target GraphSpace and graph, the source type and the data source.
+3. Multiple import tasks can be created and imported in parallel.
+
+<center>
+  <img src="/docs/images/images-hubble/332创建任务.png" alt="image">
+</center>
+
+
 ##### 4.3.4 Setting up data mapping
-1. Set up data mapping for uploaded files, including file settings and type settings
-2. File settings: Check or fill in whether to include the header, separator, encoding format and other settings of the file itself, all set the default values, no need to fill in manually
+1. Set up data mapping for the selected source, including file settings and type settings
+2. File settings: check or fill in whether to include the header, separator, encoding format and other settings of the source itself, all set the default values, no need to fill in manually
 3. Type setting:
 
      1. Vertex map and edge map:
 
-        【Vertex Type】: Select the vertex type, and upload the column data in the file for its ID mapping;
+        【Vertex Type】: Select the vertex type, and map the column data of the source for its ID;
 
-        【Edge Type】: Select the edge type and map the column data of the uploaded file to the ID column of its start point type and end point type;
-     2. Mapping settings: upload the column data in the file for the attribute mapping of the selected vertex type. Here, if the attribute name is the same as the header name of the file, the mapping attribute can be automatically matched, and there is no need to manually fill in the selection.
+        【Edge Type】: Select the edge type and map the column data of the source to the ID column of its start point type and end point type;
+     2. Mapping settings: map the column data of the source to the properties of the selected vertex type. Here, if the property name is the same as the header name of the file, the mapping property can be automatically matched, and there is no need to manually fill in the selection.
      3. After completing the setting, the setting list will be displayed before proceeding to the next step. It supports the operations of adding, editing and deleting mappings.
 
 Fill in the settings map:
@@ -346,7 +383,7 @@ Mapping list:
 
 
 ##### 4.3.5 Import data
-Before importing, you need to fill in the import setting parameters. After filling in, you can start importing data into the gallery.
+The last step chooses when the task runs: Run Once for a one-off import, Scheduled with a Quartz cron expression such as `0 0/5 * * * ?`, or Realtime for a Kafka source.
 1. Import settings
 - The import setting parameter items are as shown in the figure below, all set the default value, no need to fill in manually
 
@@ -356,8 +393,8 @@ Before importing, you need to fill in the import setting parameters. After filli
 
 
 2. Import details
-- Click Start Import to start the file import task
-- The import details provide the mapping type, import speed, import progress, time-consuming and the specific status of the current task set for each uploaded file, and can pause, resume, stop and other operations for each task
+- Run a task from the task list to start the import, and pause, edit or delete it from the same list
+- The execution history of a task provides the execution instance ID, the number of imported records, the average rate in records per second, the import duration and the status of each run
 - If the import fails, you can view the specific reason
 
 <center>
@@ -365,29 +402,31 @@ Before importing, you need to fill in the import setting parameters. After filli
 </center>
 
 
-#### 4.4 Data Analysis
+#### 4.4 Graph Query
 ##### 4.4.1 Module entry
-Left navigation:
+Left navigation, under Graph Query: [GQL Traversal].
 <center>
   <img src="/docs/images/images-hubble/341分析入口.png" alt="image">
 </center>
 
 
 ##### 4.4.2 Multi-graphs switching
-By switching the entrance on the left, flexibly switch the operation space of multiple graphs
+The top bar carries the current GraphSpace and graph, so you can flexibly switch the operation space of multiple graphs without leaving the page.
 <center>
   <img src="/docs/images/images-hubble/342多图切换.png" alt="image">
 </center>
 
 
 ##### 4.4.3 Graph Analysis and Processing
-HugeGraph supports Gremlin, a graph traversal query language of Apache TinkerPop3. Gremlin is a general graph database query language. By entering Gremlin statements and clicking execute, you can perform query and analysis operations on graph data, and create and delete vertices/edges. vertex/edge attribute modification, etc.
+HugeGraph supports Gremlin, a graph traversal query language of Apache TinkerPop3. Gremlin is a general graph database query language. By entering Gremlin statements and clicking execute, you can perform query and analysis operations on graph data, and create and delete vertices/edges, modify vertex/edge properties, etc. When the connected Server supports Cypher, a Cypher tab is offered next to Gremlin. A Text2GQL tab is present as a user interface preview only: it is not connected to a model or a query service, and nothing entered there is sent or executed.
 
-After Gremlin query, below is the graph result display area, which provides 3 kinds of graph result display modes: [Graph Mode], [Table Mode], [Json Mode].
+Each statement can run in one of two modes. Immediate returns the result inline and suits analyses that finish within about 30 seconds; Async submits a task instead, and its progress and result appear under Async Tasks. `Ctrl`/`Command` + `Enter` runs the current statement.
+
+After the query, below is the graph result display area, which provides 3 kinds of graph result display modes: [Graph Mode], [Table Mode], [Json Mode]. The graph canvas can be rendered in 2D or 3D.
 
 > ⚠️ **SEC Reminder**: Hubble allows the direct input and execution of native Gremlin query statements on the web interface, which grants users relatively high operational privileges. **Please avoid exposing the Hubble service to public network environments**. It is recommended to ensure that the graph database server has enabled the **[Authentication System (Auth)](/docs/config/config-authentication/)** combined with an **IP Whitelist** for strict permission control when in use, preventing unauthorized access or malware execution risks.
 
-Support zoom, center, full screen, export and other operations.
+Support zoom, center, full screen, layout and style configuration, legend, minimap, undo and redo, and export operations. The canvas can be exported as JSON, CSV or an image, and a previously exported canvas can be imported again.
 
 【Picture Mode】
 <center>
@@ -461,24 +500,28 @@ Right-click a vertex in the graph result to add the outgoing or incoming edge of
 </center>
 
 
-#### 4.5 Task Management
+#### 4.5 Async Tasks
 ##### 4.5.1 Module entry
-Left navigation:
+Left navigation, under Graph Query: [Async Tasks].
 <center>
    <img src="/docs/images/images-hubble/351任务管理入口.png" alt="image">
 </center>
 
 
 ##### 4.5.2 Task Management
-1. Provide unified management and result viewing of asynchronous tasks. There are 4 types of asynchronous tasks, namely:
+1. Provide unified management and result viewing of asynchronous tasks. The task types are:
 - gremlin: Gremlin tasks
-- algorithm: OLAP algorithm task
+- cypher: Cypher tasks
+- computer-dis: algorithm tasks
 - remove_schema: remove metadata
+- create_index: create an index
 - rebuild_index: rebuild the index
-2. The list displays the asynchronous task information of the current graph, including task ID, task name, task type, creation time, time-consuming, status, operation, and realizes the management of asynchronous tasks.
+- vermeer-task:load: Vermeer graph load tasks
+- vermeer-task:compute: Vermeer graph compute tasks
+2. The list displays the asynchronous task information of the current graph, including task ID, task name, task type, creation time, time-consuming, status, operation, and realizes the management of asynchronous tasks. The list refreshes every 5 seconds.
 3. Support filtering by task type and status
 4. Support searching for task ID and task name
-5. Asynchronous tasks can be deleted or deleted in batches
+5. A running task can be cancelled, and asynchronous tasks can be deleted one by one or in batches
 
 <center>
   <img src="/docs/images/images-hubble/352任务列表.png" alt="image">
@@ -488,7 +531,7 @@ Left navigation:
 ##### 4.5.3 Gremlin asynchronous tasks
 1. Create a task
 
-- The data analysis module currently supports two Gremlin operations, Gremlin query and Gremlin task; if the user switches to the Gremlin task, after clicking execute, an asynchronous task will be created in the asynchronous task center;
+- The graph query module supports two execution modes, immediate query and asynchronous task; if the user switches to the asynchronous mode, after clicking execute, an asynchronous task will be created in the asynchronous task center. A Cypher statement creates a Cypher task in the same way;
 2. Task submission
 - After the task is submitted successfully, the graph area returns the submission result and task ID
 3. Mission details
@@ -507,11 +550,11 @@ Click to view the entry to jump to the task management list, as follows:
 
 
 4. View the results
-- The results are displayed in the form of JSON
+- The results are displayed in the form of JSON, and a compact result can be expanded inline
 
 
-##### 4.5.4 OLAP algorithm tasks
-There is no visual OLAP algorithm execution on Hubble. You can call the RESTful API to perform OLAP algorithm tasks, find the corresponding tasks by ID in the task management, and view the progress and results.
+##### 4.5.4 Algorithm tasks
+Batch algorithms submitted from [Built-in Graph Algorithms] land here as algorithm tasks, and so do Vermeer graph load and compute tasks. Find a task by ID in the list and open it to follow its progress and result. See section 4.6 for the algorithm forms themselves.
 
 ##### 4.5.5 Delete metadata, rebuild index
 1. Create a task
@@ -536,16 +579,42 @@ There is no visual OLAP algorithm execution on Hubble. You can call the RESTful 
 </center>
 
 
+#### 4.6 Built-in Graph Algorithms
+
+[Built-in Graph Algorithms] under Graph Query provides parameter forms for the algorithms the Server exposes, grouped by intent: explore neighborhoods, find paths and connections, compare and rank, measure importance, find communities, and analyze graph structure. Each algorithm links to its official API documentation.
+
+Two execution modes are offered:
+
+- Interactive exploration runs the Server's OLTP traverser APIs and returns results directly. It covers K-out and K-neighbor, shortest path in its single source, weighted, and multi-node forms, paths and all paths, customized and template paths, rings and rays, crosspoints and customized crosspoints, same neighbors, Jaccard similarity, fusiform similarity, Adamic-Adar, resource allocation, egonet, and the rank and neighbor rank APIs.
+- Cluster batch computation submits an asynchronous job over the whole graph and reports the result under Async Tasks. It covers PageRank and personal PageRank, degree, closeness and betweenness centrality, K-core, weakly connected components, label propagation, Louvain, triangle count, cluster coefficient, rings detection, subgraph matching and links, with Vermeer variants where the deployment provides Vermeer.
+
+Batch algorithms need a HugeGraph Computer environment, including Kubernetes when the deployment requires it. When Computer cannot be reached, the page says so instead of submitting the task.
+
+#### 4.7 Sign-in and account management
+
+When the connected Server has authentication enabled, Hubble opens the sign-in page at `/login`. Sign in with a HugeGraph Server account: Hubble forwards the credentials to the Server and keeps the returned token for the browser session, and it stores no accounts of its own. Login attempts are throttled, so after the first three failures for the same account and address, further attempts back off starting at 5 seconds and doubling up to 600 seconds. When the Server allows anonymous access, `/login` redirects to the home page and the profile and account pages are hidden.
+
+[My Profile] shows the account details and changes the password. [Account Management] is available to accounts that may manage accounts or GraphSpace members. It creates accounts and assigns one of four access presets: Super Administrator, GraphSpace Read-only, GraphSpace Read-write and GraphSpace Administrator. Low-level role, target, access and belong records are not exposed in the interface.
+
+#### 4.8 Cluster operations
+
+In PD mode, [System & Operations] adds [Cluster Overview] and [Node details] for accounts with the matching capabilities. Cluster Overview shows the topology, per-tier node status and cluster facts such as stores online, PD leader, capacity, data size, graphs, partitions and replicas. Node details lists every discovered node with filters for type and status, and opens a node profile with its metrics, leader role and Raft shards. Node details is also available in standalone mode; Cluster Overview needs PD.
+
+An optional external dashboard can be linked from the navigation page through `dashboard.address`. It is a separate monitoring entry, and leaving it unconfigured does not affect Cluster Overview or Node details.
+
 ### 5 Configuration
 
 HugeGraph-Hubble can be configured through the `conf/hugegraph-hubble.properties` file.
 
-#### 5.1 Server Configuration
+#### 5.1 Service Configuration
 
 | Configuration Item | Default Value | Description |
 |-------------------|---------------|-------------|
-| `hubble.host` | `0.0.0.0` | The address that Hubble service binds to |
-| `hubble.port` | `8088` | The port that Hubble service listens on |
+| `server.host` | `localhost` | The address that Hubble binds to. The Docker image rewrites it to `0.0.0.0` |
+| `server.port` | `8088` | The port that Hubble listens on |
+| `server.protocol` | `http` | Protocol used to reach HugeGraphServer, `http` or `https` |
+| `ssl.client_truststore_file` | `conf/hugegraph.truststore` | Client truststore path, used when `server.protocol=https` |
+| `ssl.client_truststore_password` | `hugegraph` | Client truststore password, used when `server.protocol=https` |
 
 #### 5.2 Server and PD
 
@@ -555,7 +624,10 @@ HugeGraph-Hubble can be configured through the `conf/hugegraph-hubble.properties
 | `server.direct_url` | `http://127.0.0.1:8080` | Server address used when `pd.enabled=false` |
 | `pd.peers` | `127.0.0.1:8686` | PD node address |
 | `pd.server` | `127.0.0.1:8620` | PD service address |
+| `cluster` | `hg` | Name of the cluster Hubble connects to |
 | `route.type` | `NODE_PORT` | Service routing mode: `NODE_PORT`, `DDS`, or `BOTH` |
+| `client.request_timeout` | `60` | Request timeout in seconds for the HugeGraph client |
+| `client.url_cache_max_entries` | `1024` | Discovered URL scopes retained for stale fallback |
 
 #### 5.3 Gremlin Query Limits
 
@@ -567,3 +639,36 @@ These settings control query result limits to prevent memory issues:
 | `gremlin.vertex_degree_limit` | `100` | Maximum vertex degree to display |
 | `gremlin.edges_total_limit` | `500` | Maximum number of edges returned |
 | `gremlin.batch_query_ids` | `100` | ID batch query size |
+| `execute-history.show_limit` | `500` | Number of execution records kept for display |
+
+#### 5.4 File Upload
+
+These keys are not written into the packaged file; add them to override the defaults.
+
+| Configuration Item | Default Value | Description |
+|-------------------|---------------|-------------|
+| `upload_file.location` | `upload-files` | Directory that holds uploaded files |
+| `upload_file.format_list` | `csv,txt` | Accepted upload formats |
+| `upload_file.single_file_size_limit` | 1 GB | Size limit for one uploaded file |
+| `upload_file.total_file_size_limit` | 10 GB | Total size limit for uploaded files |
+| `upload_file.max_uploading_time` | `43200` | Seconds before unfinished upload parts are cleared |
+
+#### 5.5 Cluster Operations
+
+These keys drive the Cluster Overview and Node details pages.
+
+| Configuration Item | Default Value | Description |
+|-------------------|---------------|-------------|
+| `operations.connect_timeout_ms` | `1500` | Connection timeout for each operations upstream |
+| `operations.read_timeout_ms` | `2500` | Read timeout for each operations upstream |
+| `operations.max_response_bytes` | `1048576` | Maximum accepted body size from an operations upstream |
+| `operations.cache_ttl_seconds` | `5` | Lifetime of a fresh operations snapshot |
+| `operations.cache_max_entries` | `1024` | Operations snapshots retained across credentials |
+| `operations.store_threads` | `16` | Concurrent Store metric collection tasks |
+| `operations.store_deadline_ms` | `5000` | Deadline for one Store metric collection pass |
+| `operations.store.allowed_targets` | `[http://127.0.0.1:8520,http://[::1]:8520]` | Exact Store metric origins Hubble may contact |
+| `operations.pd.username` / `operations.pd.password` | `hubble` / empty | PD service identity used by the backend only |
+| `operations.store.username` / `operations.store.password` | `hubble` / empty | Store service identity used by the backend only |
+| `dashboard.address` | `127.0.0.1:8092` | Optional external dashboard; empty hides the entry |
+
+> The `operations.store.allowed_targets` default covers local testing only. A production deployment must list every trusted Store scheme, host and port explicitly, because discovery never adds an origin to this allowlist. HTTPS origins keep their configured hostname for TLS SNI and certificate verification. Supply the PD and Store passwords through a protected deployment configuration rather than the packaged file.


### PR DESCRIPTION
## Purpose of the PR

Sync the hugegraph-hubble docs (en + cn) with hugegraph-toolchain master (3b385c3d). Both language pages were checked section by section against the code; every row below is traced to a file on master, and the en and cn pages keep an identical heading structure.

All source paths are relative to the `apache/hugegraph-toolchain` repository at `3b385c3d`.

| Page | What was wrong | What changed | Source on master |
|------|----------------|--------------|------------------|
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Security notice said Hubble has no Auth/Login and that it is planned for 1.8.0 | Describes the real behaviour: a sign-in page appears when the connected Server has auth enabled, credentials are forwarded to the Server, account pages are hidden under anonymous access, and the plain HTTP listener still needs HTTPS in front | hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/auth/LoginController.java:76 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Module list named Graph Management / Graph Analysis / Task Management | Replaced with the modules the navigation actually has: Graph Overview, Metadata Modeling, Data Import, Graph Query, Built-in Graph Algorithms, Async Tasks, System and Operations | hugegraph-hubble/hubble-fe/src/components/Sidebar/index.ant.js:68 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | No compatibility information | Added section 1.1 with the Server/PD/Store support matrix | hugegraph-hubble/README.md:44 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | No JDK requirement stated | Stated Java 11 for the backend and the image, and that the start script only checks for a `java` binary on the PATH | hugegraph-hubble/hubble-be/pom.xml:35 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Docker note told users to set the Server hostname on the Hubble web page | The web page has no host/port field any more; the Server address comes from `server.direct_url` or PD discovery in `conf/hugegraph-hubble.properties` | hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/options/HubbleOptions.java:282 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | `docker run` and compose examples could not reach a Server in another container | Documented what the image does (rewrites `server.host=0.0.0.0`, clears `dashboard.address`, exposes 8088, runs `start-hubble.sh -f`) and added a mounted properties file to both examples | hugegraph-hubble/Dockerfile:47 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Docker images pinned to 1.5.0 | Bumped to 1.7.0, matching the binary download section and the rest of the site | hugegraph-toolchain/pom.xml:101 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | `bin/start-hubble.sh` documented with no options | Added the `-f` / `--foreground` and `-d` / `--debug` options, the JVM flags, the PID and log file paths, and the 30 second wait on `/about` | hugegraph-hubble/hubble-dist/assembly/static/bin/start-hubble.sh:58 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | `bin/stop-hubble.sh` documented as a bare stop | Documented the SIGTERM first, SIGKILL after `STOP_TIMEOUT` (default 30s) behaviour | hugegraph-hubble/hubble-dist/assembly/static/bin/stop-hubble.sh:60 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Source build section had no local development guidance | Added `yarn dev` for the frontend and the note that `spring-boot:run` is not configured for the backend | hugegraph-hubble/README.md:52 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Graph creation described graph ID, host name, port, username and password fields | The form takes graph name, alias, schema template and sample data; creation is only offered on REST API 0.67 or later | hugegraph-hubble/hubble-fe/src/pages/Graph/EditLayer.js:337, hugegraph-client/src/main/java/org/apache/hugegraph/driver/ServerCompatibility.java:32 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | No mention of GraphSpaces | Section 4.1 now covers Graph Space Management in PD mode and the single `DEFAULT` GraphSpace in standalone mode | hugegraph-hubble/hubble-fe/src/utils/productMode.js:21, hugegraph-hubble/hubble-fe/src/routes/index.js:95 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Graph list actions were only overview, search, edit and delete | Listed the real actions: View Schema with Groovy export, Metadata Config, Clone Graph, Clear Schema and Data, Delete, Set Default, plus the three demo graphs | hugegraph-hubble/hubble-fe/src/i18n/resources/en-US/modules/pages.json:225 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Three "Reuse" subsections described a metadata reuse feature | Removed; the metadata pages carry no reuse entry and no reuse i18n key remains in the frontend | hugegraph-hubble/hubble-fe/src/pages/Meta/ListView.js:29 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Edge type creation did not mention the type field | Added Normal / Parent / Sub for edge type hierarchies | hugegraph-hubble/hubble-fe/src/i18n/resources/en-US/modules/pages.json:1098 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Metadata section had no Schema Templates | Added 4.2.6 covering the per-GraphSpace template library and its example versus user templates | hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/space/SchemaTemplateController.java:48 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Data import described "create a task then upload CSV files" | Rewrote around Data Sources (FILE, HDFS, Kafka, JDBC) and the four-step task wizard, plus the Run Once / Scheduled / Realtime schedule step | hugegraph-hubble/hubble-fe/src/pages/Datasource/config.js:20, hugegraph-hubble/hubble-fe/src/pages/TaskEdit/index.js:325 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Upload format said "CSV only", with no size limits | Accepted formats default to `csv` and `txt`, with the 1 GB / 10 GB / 12 hour limits | hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/options/HubbleOptions.java:180 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Query section covered Gremlin only | Added the Cypher tab, the Text2GQL preview tab, immediate versus async execution, and 2D/3D rendering | hugegraph-hubble/hubble-fe/src/i18n/resources/en-US/modules/analysis.json:5, hugegraph-hubble/hubble-fe/src/modules/component/GraphRenderModeSwitcher/index.js:33 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Async task types listed only 4 kinds | Listed all 8 kinds and added the 5 second auto refresh and task cancellation | hugegraph-hubble/hubble-fe/src/utils/constants.js:138, hugegraph-hubble/hubble-fe/src/modules/asyncTasks/Home/index.js:119 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Said "There is no visual OLAP algorithm execution on Hubble" | Replaced with the real Built-in Graph Algorithms page as new section 4.6, covering the OLTP and OLAP forms and the Computer requirement | hugegraph-hubble/hubble-fe/src/modules/algorithm/algorithmsForm/OltpHome/index.js:32, hugegraph-hubble/hubble-fe/src/modules/algorithm/algorithmsForm/OlapHome/index.js:34 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | No sign-in or account documentation | Added section 4.7 for the login page, the login backoff and the four GraphSpace permission presets | hugegraph-hubble/hubble-be/src/main/resources/application.properties:31, hugegraph-hubble/hubble-fe/src/i18n/resources/en-US/modules/pages.json:403 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | No cluster operations documentation | Added section 4.8 for Cluster Overview, Node details and the optional external dashboard | hugegraph-hubble/hubble-fe/src/routes/index.js:210, hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/op/DashboardController.java:49 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Config table used `hubble.host` / `hubble.port` with default `0.0.0.0` | Corrected to `server.host` (default `localhost`) and `server.port` (default `8088`), and added the protocol and truststore keys | hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/options/HubbleOptions.java:60, hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/config/TomcatServletConfig.java:45 |
| content/{en,cn}/docs/quickstart/toolchain/hugegraph-hubble.md | Config section covered only server, PD and Gremlin limits | Added `cluster`, `client.request_timeout`, `client.url_cache_max_entries`, `execute-history.show_limit`, the `upload_file.*` keys, and the `operations.*` and `dashboard.address` keys with the Store allowlist warning | hugegraph-hubble/hubble-dist/assembly/static/conf/hugegraph-hubble.properties:26, hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/options/HubbleOptions.java:371 |

Note: `graph_connection.ip_white_list` and `graph_connection.port_white_list` are still declared in `HubbleOptions` but are not read anywhere in `hubble-be/src/main`, and they are not present in the packaged `conf/hugegraph-hubble.properties`, so they were left out of the configuration tables.
