### PR TITLE
doc(ai): sync hugegraph-python-client with main

### DIFF
--- a/content/cn/docs/quickstart/client/hugegraph-client-python.md
+++ b/content/cn/docs/quickstart/client/hugegraph-client-python.md
@@ -6,27 +6,33 @@ weight: 2
 
 `hugegraph-python-client` 是 HugeGraph 的 Python SDK，可管理 Schema、读写图数据并执行 Gremlin 查询。HugeGraph-LLM 和 HugeGraph-ML 也使用这个客户端。
 
+该模块位于 [hugegraph-ai](https://github.com/apache/hugegraph-ai) 仓库的 `hugegraph-python-client/` 目录下，导入名为 `pyhugegraph`。
+
 ## 环境要求
 
-- Python 3.9 或更高版本
-- 可访问的 HugeGraph Server
+- 客户端本身要求 Python 3.9 或更高版本。HugeGraph-AI workspace 要求 Python 3.10 或更高版本，CI 在 3.10 和 3.11 上运行客户端测试。
+- HugeGraph Server 1.5.0 或更高版本。客户端会拒绝连接更低版本的 Server，此类场景请改用 v1.3.x 客户端。
 - `uv`（推荐）或 `pip`
+
+运行时依赖为 `decorator`、`requests`、`setuptools`、`urllib3` 和 `rich`。
 
 ## 安装
 
-PyPI 上的包名目前是 `hugegraph-python`：
+发布到 PyPI 的包名是 `hugegraph-python`：
 
 ```bash
 uv pip install hugegraph-python
 # 也可以使用 pip install hugegraph-python
 ```
 
-如需使用仓库中的最新代码，请从 HugeGraph-AI 仓库根目录同步 workspace：
+> PyPI 上的发布版本落后于仓库代码。在源码中该发行包声明为 `hugegraph-python-client`，版本号与 HugeGraph-AI 其他模块保持一致，需要最新代码时请从源码安装。
+
+如需使用仓库中的最新代码，请从 HugeGraph-AI 仓库根目录同步 workspace。`hugegraph-python-client` 是 workspace 成员，通过 `python-client` extra 暴露，因此仅执行 `uv sync` 不会安装它：
 
 ```bash
 git clone https://github.com/apache/hugegraph-ai.git
 cd hugegraph-ai
-uv sync
+uv sync --extra python-client
 source .venv/bin/activate
 ```
 
@@ -36,11 +42,11 @@ source .venv/bin/activate
 from pyhugegraph.client import PyHugeClient
 
 client = PyHugeClient(
-    "127.0.0.1:8080",
+    url="http://127.0.0.1:8080",
     graph="hugegraph",
     user="admin",
     pwd="admin",
-    graphspace="DEFAULT",
+    graphspace=None,
 )
 
 schema = client.schema()
@@ -65,30 +71,153 @@ print(graph.getEdgeById(edge.id))
 graph.close()
 ```
 
-如果 HugeGraph 没有启用 GraphSpace，可以省略 `graphspace`。启用后请传入实际空间名；默认空间通常是 `DEFAULT`。
+### 客户端参数
+
+`PyHugeClient(url, graph, user, pwd, graphspace=None, timeout=None)`
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `url` | `str` | 必填 | HugeGraph Server 的基础 URL。若未带协议头，客户端会自动补上 `http://`，因此 `127.0.0.1:8080` 也可以使用。 |
+| `graph` | `str` | 必填 | 图名称，是第二个位置参数。 |
+| `user` | `str` | 必填 | 用户名，以 HTTP Basic Auth 发送。 |
+| `pwd` | `str` | 必填 | 密码，以 HTTP Basic Auth 发送。 |
+| `graphspace` | `str` 或 `None` | `None` | GraphSpace 名称，`None` 的解析规则见下文。 |
+| `timeout` | `tuple[float, float]` 或 `None` | `None` | `(连接, 读取)` 超时时间，单位为秒。`None` 会取 `(0.5, 15.0)`。 |
+
+每个 HTTP 会话在收到 500、502、504 响应时会重试 3 次，退避因子为 0.1。
+
+### Server 版本与 GraphSpace
+
+客户端在构造时解析 GraphSpace：
+
+- 传入非空的 `graphspace` 字符串时直接开启 GraphSpace 模式。
+- 否则客户端会请求 `GET {url}/versions` 并读取 `versions.core`。
+- Server 版本低于 1.5.0 时抛出 `RuntimeError`，提示升级 Server 或改用 v1.3.x 客户端。
+- Server 版本高于 1.5.0 时会把 `graphspace` 设为 `DEFAULT` 并开启 GraphSpace 模式，同时在日志中打印警告。版本恰好为 1.5.0 时保持关闭。
+- 若因网络原因探测失败，GraphSpace 模式保持关闭。
+
+该模式决定请求前缀：开启时为 `/graphspaces/<graphspace>/graphs/<graph>/...`，关闭时为 `/graphs/<graph>/...`。
+
+### 客户端提供的 Manager
+
+每个访问器都会惰性创建对应的 Manager，并为其分配独立的 HTTP 会话。
+
+| 访问器 | Manager | 覆盖范围 |
+|--------|---------|----------|
+| `client.schema()` | `SchemaManager` | 属性、顶点标签、边标签、索引标签 |
+| `client.graph()` | `GraphManager` | 顶点与边的增删改查、批量写入、分页 |
+| `client.gremlin()` | `GremlinManager` | 执行 Gremlin |
+| `client.graphs()` | `GraphsManager` | 图列表、图信息、配置、清空数据 |
+| `client.traverser()` | `TraverserManager` | 遍历与路径算法 |
+| `client.variable()` | `VariableManager` | 图变量 |
+| `client.task()` | `TaskManager` | 异步任务的查询、取消、删除 |
+| `client.auth()` | `AuthManager` | 用户、用户组、资源、归属、权限 |
+| `client.metrics()` | `MetricsManager` | Server 指标 |
+| `client.version()` | `VersionManager` | Server 版本 |
+
+`pyhugegraph.api` 中还提供了 `RankManager`、`RebuildManager` 和 `ServicesManager`，但 `PyHugeClient` 暂未提供对应的访问器，需要时可自行传入 session 构造。
 
 ## 常用操作
+
+### 构建 Schema
+
+Schema 构建器采用链式调用，最后调用 `create()`，也可以用 `append()`、`eliminate()` 和 `remove()` 修改已有定义。
+
+```python
+schema = client.schema()
+
+# 属性类型：asText/asInt/asLong/asFloat/asDouble/asBool/asByte/asBlob/asDate/asObject
+# 基数：valueSingle/valueList/valueSet
+# 聚合：calcMax/calcMin/calcSum/calcOld
+schema.propertyKey("age").asInt().valueSingle().ifNotExist().create()
+
+# 顶点标签 ID 策略：useAutomaticId/useCustomizeStringId/useCustomizeNumberId/usePrimaryKeyId
+schema.vertexLabel("person").properties("name", "age", "city") \
+      .primaryKeys("name").nullableKeys("city").ifNotExist().create()
+
+# 边标签：link() 等价于 sourceLabel() 加 targetLabel()
+schema.edgeLabel("knows").link("person", "person").multiTimes() \
+      .properties("date", "city").sortKeys("date").nullableKeys("city") \
+      .ifNotExist().create()
+
+# 索引标签：先 onV/onE，再选择 secondary/range/search/shard/unique
+schema.indexLabel("personByCity").onV("person").by("city") \
+      .secondary().ifNotExist().create()
+```
 
 ### 查询 Schema
 
 ```python
 schema = client.schema()
+print(schema.getSchema())            # 完整 Schema，format 默认为 json
 print(schema.getPropertyKeys())
 print(schema.getVertexLabels())
 print(schema.getEdgeLabels())
 print(schema.getIndexLabels())
+
+# 查询单个定义
+print(schema.getPropertyKey("name"))
+print(schema.getVertexLabel("person"))
+print(schema.getEdgeLabel("knows"))
+print(schema.getIndexLabel("personByCity"))
+
+# 边标签的连接关系，格式形如 Person--ActedIn-->Movie
+print(schema.getRelations())
 ```
 
-### 更新和删除图数据
+### 读取、更新和删除图数据
 
-图接口直接接收对象属性字典：
+图接口直接接收属性字典，不支持链式的属性构建器：
 
 ```python
 graph = client.graph()
-graph.appendVertex(person.id, {"birthDate": "1940-04-25"})
+graph.appendVertex(person.id, {"birthDate": "1940-04-25"})    # 追加属性
+graph.eliminateVertex(person.id, {"birthDate": "1940-04-25"}) # 删除属性
+graph.appendEdge(edge.id, {"city": "Beijing"})
+graph.eliminateEdge(edge.id, {"city": "Beijing"})
 graph.removeEdgeById(edge.id)
 graph.removeVertexById(person.id)
 graph.close()
+```
+
+`addVertex` 返回 `VertexData`，包含 `id`、`label`、`type` 和 `properties`。`addEdge` 返回 `EdgeData`，包含 `id`、`label`、`type`、`outV`、`outVLabel`、`inV`、`inVLabel` 和 `properties`。
+
+传给客户端的顶点 ID 可以是字符串、整数或 `uuid.UUID`。布尔值会被拒绝，整数必须落在 Java signed long 范围内。
+
+### 批量写入
+
+`addVertices` 接收 `(label, properties)` 二元组，`addEdges` 接收 `(label, out_id, in_id, out_label, in_label, properties)` 六元组。两者返回的对象只携带生成的 ID。
+
+```python
+graph = client.graph()
+vertices = graph.addVertices([
+    ("person", {"name": "Alice", "age": 20}),
+    ("person", {"name": "Bob", "age": 23}),
+])
+edges = graph.addEdges([
+    ("knows", vertices[0].id, vertices[1].id, "person", "person", {"date": "2012-01-10"}),
+])
+```
+
+### 分页与条件查询
+
+```python
+graph = client.graph()
+
+# 返回 (vertices, next_page)，把 next_page 传回即可继续翻页
+vertices, next_page = graph.getVertexByPage("person", limit=10)
+vertices, next_page = graph.getVertexByPage("person", limit=10, page=next_page)
+
+# 服务端属性条件
+older = graph.getVertexByCondition("person", properties={"age": "P.gt(29)"})
+
+# 边分页查询，传入 vertex_id 时必须同时传 direction
+edges, next_page = graph.getEdgeByPage(label="knows", limit=10)
+edges, next_page = graph.getEdgeByPage(vertex_id=person.id, direction="OUT", limit=10)
+
+# 按 ID 批量查询
+graph.getVerticesById([v1.id, v2.id])
+graph.getEdgesById([e1.id, e2.id])
 ```
 
 ### 执行 Gremlin
@@ -97,6 +226,140 @@ graph.close()
 gremlin = client.gremlin()
 result = gremlin.exec("g.V().limit(5)")
 print(result)
+```
+
+`exec` 会根据图名称和解析出的 GraphSpace 自动绑定 `graph` 与 `g` 别名，并返回服务端响应中的 `result` 字段。响应缺少 `requestId`、`status` 或 `result` 时抛出 `ResponseParseError`。
+
+### 图遍历
+
+`TraverserManager` 封装了 Server 的 traverser 接口，方法名使用蛇形命名。
+
+```python
+traverser = client.traverser()
+
+traverser.k_out(marko_id, 2)
+traverser.k_neighbor(marko_id, 2)
+traverser.same_neighbors(marko_id, josh_id)
+traverser.jaccard_similarity(marko_id, josh_id)
+traverser.shortest_path(marko_id, ripple_id, 3)
+traverser.all_shortest_paths(marko_id, ripple_id, 3)
+traverser.weighted_shortest_path(marko_id, ripple_id, "weight", 3)
+traverser.single_source_shortest_path(marko_id, 2)
+traverser.multi_node_shortest_path([marko_id, josh_id], max_depth=2)
+traverser.paths(marko_id, josh_id, 2)
+traverser.crosspoints(marko_id, josh_id, 2)
+traverser.rings(marko_id, 3)
+traverser.rays(marko_id, 2)
+traverser.vertices(marko_id)
+traverser.edges(edge_id)
+```
+
+基于 POST 的接口需要传入请求体：`advanced_paths`、`customized_paths`、`template_paths`、`customized_crosspoints` 和 `fusiform_similarity`。
+
+### 图变量
+
+```python
+variable = client.variable()
+variable.set("owner", "mary")
+print(variable.get("owner"))
+print(variable.all())
+variable.remove("owner")
+```
+
+### 异步任务
+
+```python
+task = client.task()
+print(task.list_tasks(status="success", limit=10))
+print(task.get_task(task_id))
+task.cancel_task(task_id)
+task.delete_task(task_id)
+```
+
+### Server 指标与图信息
+
+```python
+metrics = client.metrics()
+metrics.get_all_basic_metrics()
+metrics.get_gauges_metrics()
+metrics.get_counters_metrics()
+metrics.get_histograms_metrics()
+metrics.get_meters_metrics()
+metrics.get_timers_metrics()
+metrics.get_statistics_metrics()
+metrics.get_system_metrics()
+metrics.get_backend_metrics()
+
+graphs = client.graphs()
+graphs.get_all_graphs()
+graphs.get_version()
+graphs.get_graph_info()
+graphs.get_graph_config()
+graphs.clear_graph_all_data()   # 删除全部顶点、边和 Schema
+
+print(client.version().version())
+```
+
+### 认证与授权
+
+`AuthManager` 与 Server 的路由保持一致：用户、资源、归属和权限挂载在 `/graphspaces/{graphspace}/auth/...` 下，用户组仍在 Server 级别的 `/auth/groups`。在 HugeGraph 1.7.0 及以上版本必须能解析出 graphspace，否则这些调用会在发出请求前抛出 `ValueError`。
+
+```python
+auth = client.auth()
+
+user = auth.create_user("test_user", "password")
+auth.modify_user(user["id"], user_email="hugegraph@apache.org")
+auth.get_user(user["id"])
+auth.list_users(limit=10)
+auth.delete_user(user["id"])
+
+group = auth.create_group("test_group", "read only")
+auth.modify_group(group["id"], group_description="updated")
+auth.list_groups()
+auth.delete_group(group["id"])
+
+target = auth.create_target("target1", "hugegraph", "127.0.0.1:8080", [])
+auth.update_target(target["id"], "target1", "hugegraph", "127.0.0.1:8080", [])
+auth.list_targets()
+auth.delete_target(target["id"])
+
+belong = auth.create_belong(user["id"], group["id"])
+auth.update_belong(belong["id"], "description")
+auth.list_belongs()
+auth.delete_belong(belong["id"])
+
+access = auth.grant_accesses(group["id"], target["id"], "READ")
+auth.modify_accesses(access["id"], "description")
+auth.list_accesses()
+auth.revoke_accesses(access["id"])
+```
+
+## 方法命名
+
+Manager 中以驼峰命名的方法（例如 `addVertex`、`getVertexById`）会在构造时自动生成蛇形命名别名，`graph.add_vertex(...)` 与 `graph.addVertex(...)` 指向同一个方法。驼峰写法已在 debug 日志中标记为废弃，新代码建议使用蛇形命名。
+
+## 错误处理
+
+异常定义在 `pyhugegraph.utils.exceptions` 中：
+
+| 异常 | 触发条件 |
+|------|----------|
+| `NotAuthorizedError` | Server 返回 401 |
+| `NotFoundError` | Server 返回 404，或缺少必填参数 |
+| `ServerError` | 其他非 2xx 响应，异常信息中附带服务端消息 |
+| `ResponseParseError` | 成功响应无法解析为预期结构 |
+| `ServiceUnavailableError` | Server 返回 `ServiceUnavailableException` |
+| `InvalidParameterError`、`CreateError`、`RemoveError`、`UpdateError`、`DataFormatError` | 由各构建器和数据结构抛出 |
+
+请求体与响应体写入日志时，会对密码、token 和 secret 等字段做脱敏处理。
+
+```python
+from pyhugegraph.utils.exceptions import NotFoundError
+
+try:
+    graph.getVertexById("no-such-id")
+except NotFoundError:
+    print("vertex missing")
 ```
 
 接口参数会随 HugeGraph REST API 版本变化。遇到不兼容时，先核对当前 Server 的 REST API 文档与客户端测试用例。
@@ -109,4 +372,20 @@ print(result)
 ./style/code_format_and_analysis.sh
 ```
 
-源码与测试位于 `hugegraph-python-client/src/pyhugegraph/` 和 `hugegraph-python-client/src/tests/`。
+按照 CI 的方式运行测试：
+
+```bash
+# 单元测试与契约测试，无需 Server
+uv run pytest hugegraph-python-client/src/tests -m "unit or contract"
+
+# 集成测试，需要可访问的 Server
+HUGEGRAPH_URL=http://127.0.0.1:8080 \
+HUGEGRAPH_GRAPH=hugegraph \
+HUGEGRAPH_USER=admin \
+HUGEGRAPH_PASSWORD=admin \
+uv run pytest hugegraph-python-client/src/tests -m "integration and hugegraph"
+```
+
+CI 的集成测试作业使用 `hugegraph/hugegraph:1.7.0` 镜像。需要非默认空间时，还可以设置 `HUGEGRAPH_GRAPHSPACE`。
+
+源码与测试位于 `hugegraph-python-client/src/pyhugegraph/` 和 `hugegraph-python-client/src/tests/`，可直接运行的示例在 `hugegraph-python-client/src/pyhugegraph/example/hugegraph_example.py`。

--- a/content/en/docs/quickstart/client/hugegraph-client-python.md
+++ b/content/en/docs/quickstart/client/hugegraph-client-python.md
@@ -6,27 +6,33 @@ weight: 2
 
 `hugegraph-python-client` is the Python SDK for HugeGraph. It manages schemas, reads and writes graph data, and executes Gremlin queries. HugeGraph-LLM and HugeGraph-ML also use this client.
 
+The module lives in the [hugegraph-ai](https://github.com/apache/hugegraph-ai) repository under `hugegraph-python-client/`. The import name is `pyhugegraph`.
+
 ## Requirements
 
-- Python 3.9 or later
-- An accessible HugeGraph Server
+- Python 3.9 or later for the client itself. The HugeGraph-AI workspace requires Python 3.10 or later, and CI runs the client tests on 3.10 and 3.11.
+- HugeGraph Server 1.5.0 or later. The client refuses to connect to older servers; use client v1.3.x for those.
 - `uv` (recommended) or `pip`
+
+Runtime dependencies are `decorator`, `requests`, `setuptools`, `urllib3` and `rich`.
 
 ## Installation
 
-The package is currently published on PyPI as `hugegraph-python`:
+The released package is published on PyPI as `hugegraph-python`:
 
 ```bash
 uv pip install hugegraph-python
 # Alternatively: pip install hugegraph-python
 ```
 
-To use the latest repository code, sync the workspace from the root of the HugeGraph-AI repository:
+> The PyPI release lags behind the repository. In the source tree the distribution is declared as `hugegraph-python-client` and versioned with the rest of HugeGraph-AI, so install from source if you need the newest code.
+
+To use the latest repository code, sync the workspace from the root of the HugeGraph-AI repository. `hugegraph-python-client` is a workspace member exposed through the `python-client` extra, so plain `uv sync` does not pull it in:
 
 ```bash
 git clone https://github.com/apache/hugegraph-ai.git
 cd hugegraph-ai
-uv sync
+uv sync --extra python-client
 source .venv/bin/activate
 ```
 
@@ -36,11 +42,11 @@ source .venv/bin/activate
 from pyhugegraph.client import PyHugeClient
 
 client = PyHugeClient(
-    "127.0.0.1:8080",
+    url="http://127.0.0.1:8080",
     graph="hugegraph",
     user="admin",
     pwd="admin",
-    graphspace="DEFAULT",
+    graphspace=None,
 )
 
 schema = client.schema()
@@ -65,30 +71,153 @@ print(graph.getEdgeById(edge.id))
 graph.close()
 ```
 
-If GraphSpace is disabled in HugeGraph, omit `graphspace`. When it is enabled, pass the actual space name; the default space is usually `DEFAULT`.
+### Client Parameters
+
+`PyHugeClient(url, graph, user, pwd, graphspace=None, timeout=None)`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | `str` | required | Base URL of HugeGraph Server. If the value has no scheme, `http://` is prepended, so `127.0.0.1:8080` also works. |
+| `graph` | `str` | required | Graph name. This is the second positional parameter. |
+| `user` | `str` | required | Username, sent as HTTP basic auth. |
+| `pwd` | `str` | required | Password, sent as HTTP basic auth. |
+| `graphspace` | `str` or `None` | `None` | GraphSpace name. See below for how `None` is resolved. |
+| `timeout` | `tuple[float, float]` or `None` | `None` | `(connect, read)` timeouts in seconds. `None` becomes `(0.5, 15.0)`. |
+
+Every HTTP session retries three times with a 0.1 backoff factor on 500, 502 and 504 responses.
+
+### Server Version and GraphSpace
+
+The client resolves GraphSpace at construction time:
+
+- A non-empty `graphspace` string turns GraphSpace mode on directly.
+- Otherwise the client sends `GET {url}/versions` and reads `versions.core`.
+- A server older than 1.5.0 raises `RuntimeError` asking you to upgrade the server or use client v1.3.x.
+- A server newer than 1.5.0 gets `graphspace` set to `DEFAULT` and GraphSpace mode turned on, with a warning in the log. A server at exactly 1.5.0 keeps GraphSpace mode off.
+- If the probe fails for network reasons, GraphSpace mode stays off.
+
+The mode decides the request prefix: `/graphspaces/<graphspace>/graphs/<graph>/...` when GraphSpace is on, `/graphs/<graph>/...` when it is off.
+
+### Managers on the Client
+
+Each accessor builds its manager lazily and gives it a dedicated HTTP session.
+
+| Accessor | Manager | Covers |
+|----------|---------|--------|
+| `client.schema()` | `SchemaManager` | Property keys, vertex labels, edge labels, index labels |
+| `client.graph()` | `GraphManager` | Vertex and edge CRUD, batch writes, paging |
+| `client.gremlin()` | `GremlinManager` | Gremlin execution |
+| `client.graphs()` | `GraphsManager` | Graph list, graph info, config, clear data |
+| `client.traverser()` | `TraverserManager` | Traversal and path algorithms |
+| `client.variable()` | `VariableManager` | Graph variables |
+| `client.task()` | `TaskManager` | Async task list, query, cancel, delete |
+| `client.auth()` | `AuthManager` | Users, groups, targets, belongs, accesses |
+| `client.metrics()` | `MetricsManager` | Server metrics |
+| `client.version()` | `VersionManager` | Server version |
+
+`RankManager`, `RebuildManager` and `ServicesManager` also ship in `pyhugegraph.api`, but `PyHugeClient` does not expose accessors for them yet; construct them directly with a session if you need them.
 
 ## Common Operations
+
+### Build the Schema
+
+The schema builders are fluent. Call `create()` last, or `append()`, `eliminate()` and `remove()` to change an existing definition.
+
+```python
+schema = client.schema()
+
+# Property keys: asText/asInt/asLong/asFloat/asDouble/asBool/asByte/asBlob/asDate/asObject
+# cardinality: valueSingle/valueList/valueSet
+# aggregation: calcMax/calcMin/calcSum/calcOld
+schema.propertyKey("age").asInt().valueSingle().ifNotExist().create()
+
+# Vertex labels: useAutomaticId/useCustomizeStringId/useCustomizeNumberId/usePrimaryKeyId
+schema.vertexLabel("person").properties("name", "age", "city") \
+      .primaryKeys("name").nullableKeys("city").ifNotExist().create()
+
+# Edge labels: link() is shorthand for sourceLabel() plus targetLabel()
+schema.edgeLabel("knows").link("person", "person").multiTimes() \
+      .properties("date", "city").sortKeys("date").nullableKeys("city") \
+      .ifNotExist().create()
+
+# Index labels: onV/onE, then secondary/range/search/shard/unique
+schema.indexLabel("personByCity").onV("person").by("city") \
+      .secondary().ifNotExist().create()
+```
 
 ### Query the Schema
 
 ```python
 schema = client.schema()
+print(schema.getSchema())            # whole schema, format defaults to "json"
 print(schema.getPropertyKeys())
 print(schema.getVertexLabels())
 print(schema.getEdgeLabels())
 print(schema.getIndexLabels())
+
+# Single definitions
+print(schema.getPropertyKey("name"))
+print(schema.getVertexLabel("person"))
+print(schema.getEdgeLabel("knows"))
+print(schema.getIndexLabel("personByCity"))
+
+# Edge label links, formatted as "Person--ActedIn-->Movie"
+print(schema.getRelations())
 ```
 
-### Update and Delete Graph Data
+### Read, Update and Delete Graph Data
 
-The graph API accepts dictionaries containing object properties:
+The graph API takes property dictionaries, not chained property builders:
 
 ```python
 graph = client.graph()
-graph.appendVertex(person.id, {"birthDate": "1940-04-25"})
+graph.appendVertex(person.id, {"birthDate": "1940-04-25"})    # add properties
+graph.eliminateVertex(person.id, {"birthDate": "1940-04-25"}) # drop properties
+graph.appendEdge(edge.id, {"city": "Beijing"})
+graph.eliminateEdge(edge.id, {"city": "Beijing"})
 graph.removeEdgeById(edge.id)
 graph.removeVertexById(person.id)
 graph.close()
+```
+
+`addVertex` returns a `VertexData` with `id`, `label`, `type` and `properties`. `addEdge` returns an `EdgeData` with `id`, `label`, `type`, `outV`, `outVLabel`, `inV`, `inVLabel` and `properties`.
+
+Vertex ids passed to the client may be strings, integers or `uuid.UUID` values. Booleans are rejected, and integers must fit the Java signed long range.
+
+### Batch Writes
+
+`addVertices` takes `(label, properties)` pairs, and `addEdges` takes `(label, out_id, in_id, out_label, in_label, properties)` tuples. Both return objects that carry only the generated ids.
+
+```python
+graph = client.graph()
+vertices = graph.addVertices([
+    ("person", {"name": "Alice", "age": 20}),
+    ("person", {"name": "Bob", "age": 23}),
+])
+edges = graph.addEdges([
+    ("knows", vertices[0].id, vertices[1].id, "person", "person", {"date": "2012-01-10"}),
+])
+```
+
+### Paging and Conditional Queries
+
+```python
+graph = client.graph()
+
+# Returns (vertices, next_page); pass next_page back in to continue
+vertices, next_page = graph.getVertexByPage("person", limit=10)
+vertices, next_page = graph.getVertexByPage("person", limit=10, page=next_page)
+
+# Server-side property predicates
+older = graph.getVertexByCondition("person", properties={"age": "P.gt(29)"})
+
+# Edges by page. When vertex_id is given, direction is required
+edges, next_page = graph.getEdgeByPage(label="knows", limit=10)
+edges, next_page = graph.getEdgeByPage(vertex_id=person.id, direction="OUT", limit=10)
+
+# Batch lookup by id
+graph.getVerticesById([v1.id, v2.id])
+graph.getEdgesById([e1.id, e2.id])
 ```
 
 ### Execute Gremlin
@@ -97,6 +226,140 @@ graph.close()
 gremlin = client.gremlin()
 result = gremlin.exec("g.V().limit(5)")
 print(result)
+```
+
+`exec` binds the `graph` and `g` aliases for you, based on the graph name and the resolved GraphSpace, and returns the `result` field of the server response. A response missing `requestId`, `status` or `result` raises `ResponseParseError`.
+
+### Traverse the Graph
+
+`TraverserManager` wraps the server traverser endpoints. Its methods use snake_case.
+
+```python
+traverser = client.traverser()
+
+traverser.k_out(marko_id, 2)
+traverser.k_neighbor(marko_id, 2)
+traverser.same_neighbors(marko_id, josh_id)
+traverser.jaccard_similarity(marko_id, josh_id)
+traverser.shortest_path(marko_id, ripple_id, 3)
+traverser.all_shortest_paths(marko_id, ripple_id, 3)
+traverser.weighted_shortest_path(marko_id, ripple_id, "weight", 3)
+traverser.single_source_shortest_path(marko_id, 2)
+traverser.multi_node_shortest_path([marko_id, josh_id], max_depth=2)
+traverser.paths(marko_id, josh_id, 2)
+traverser.crosspoints(marko_id, josh_id, 2)
+traverser.rings(marko_id, 3)
+traverser.rays(marko_id, 2)
+traverser.vertices(marko_id)
+traverser.edges(edge_id)
+```
+
+The POST-based variants take request bodies: `advanced_paths`, `customized_paths`, `template_paths`, `customized_crosspoints` and `fusiform_similarity`.
+
+### Graph Variables
+
+```python
+variable = client.variable()
+variable.set("owner", "mary")
+print(variable.get("owner"))
+print(variable.all())
+variable.remove("owner")
+```
+
+### Async Tasks
+
+```python
+task = client.task()
+print(task.list_tasks(status="success", limit=10))
+print(task.get_task(task_id))
+task.cancel_task(task_id)
+task.delete_task(task_id)
+```
+
+### Server Metrics and Graph Info
+
+```python
+metrics = client.metrics()
+metrics.get_all_basic_metrics()
+metrics.get_gauges_metrics()
+metrics.get_counters_metrics()
+metrics.get_histograms_metrics()
+metrics.get_meters_metrics()
+metrics.get_timers_metrics()
+metrics.get_statistics_metrics()
+metrics.get_system_metrics()
+metrics.get_backend_metrics()
+
+graphs = client.graphs()
+graphs.get_all_graphs()
+graphs.get_version()
+graphs.get_graph_info()
+graphs.get_graph_config()
+graphs.clear_graph_all_data()   # deletes every vertex, edge and schema entry
+
+print(client.version().version())
+```
+
+### Authentication and Authorization
+
+`AuthManager` follows the server routing: users, targets, belongs and accesses are mounted under `/graphspaces/{graphspace}/auth/...`, while groups stay at the server-level `/auth/groups`. On HugeGraph 1.7.0 and later a graphspace must be resolved, otherwise these calls raise `ValueError` before any request is sent.
+
+```python
+auth = client.auth()
+
+user = auth.create_user("test_user", "password")
+auth.modify_user(user["id"], user_email="hugegraph@apache.org")
+auth.get_user(user["id"])
+auth.list_users(limit=10)
+auth.delete_user(user["id"])
+
+group = auth.create_group("test_group", "read only")
+auth.modify_group(group["id"], group_description="updated")
+auth.list_groups()
+auth.delete_group(group["id"])
+
+target = auth.create_target("target1", "hugegraph", "127.0.0.1:8080", [])
+auth.update_target(target["id"], "target1", "hugegraph", "127.0.0.1:8080", [])
+auth.list_targets()
+auth.delete_target(target["id"])
+
+belong = auth.create_belong(user["id"], group["id"])
+auth.update_belong(belong["id"], "description")
+auth.list_belongs()
+auth.delete_belong(belong["id"])
+
+access = auth.grant_accesses(group["id"], target["id"], "READ")
+auth.modify_accesses(access["id"], "description")
+auth.list_accesses()
+auth.revoke_accesses(access["id"])
+```
+
+## Method Naming
+
+Manager methods written in camelCase, such as `addVertex` and `getVertexById`, also get a snake_case alias generated at construction time. `graph.add_vertex(...)` and `graph.addVertex(...)` reach the same method. The camelCase spellings are marked deprecated in the debug log, so prefer snake_case in new code.
+
+## Error Handling
+
+Exceptions live in `pyhugegraph.utils.exceptions`:
+
+| Exception | Raised when |
+|-----------|-------------|
+| `NotAuthorizedError` | The server answers 401 |
+| `NotFoundError` | The server answers 404, or a required argument is missing |
+| `ServerError` | Any other non-2xx response, with the server message attached |
+| `ResponseParseError` | A successful response cannot be parsed into the expected shape |
+| `ServiceUnavailableError` | The server reports `ServiceUnavailableException` |
+| `InvalidParameterError`, `CreateError`, `RemoveError`, `UpdateError`, `DataFormatError` | Raised by individual builders and structures |
+
+Request and response bodies are logged with password, token and secret values redacted.
+
+```python
+from pyhugegraph.utils.exceptions import NotFoundError
+
+try:
+    graph.getVertexById("no-such-id")
+except NotFoundError:
+    print("vertex missing")
 ```
 
 API parameters may change with the HugeGraph REST API version. If an interface is incompatible, first check the REST API documentation for the current server version and the client test cases.
@@ -109,4 +372,20 @@ Run formatting and static checks from the root of the HugeGraph-AI repository:
 ./style/code_format_and_analysis.sh
 ```
 
-The source code and tests are under `hugegraph-python-client/src/pyhugegraph/` and `hugegraph-python-client/src/tests/`.
+Run the tests the same way CI does:
+
+```bash
+# Unit and contract tests, no server needed
+uv run pytest hugegraph-python-client/src/tests -m "unit or contract"
+
+# Integration tests against a running server
+HUGEGRAPH_URL=http://127.0.0.1:8080 \
+HUGEGRAPH_GRAPH=hugegraph \
+HUGEGRAPH_USER=admin \
+HUGEGRAPH_PASSWORD=admin \
+uv run pytest hugegraph-python-client/src/tests -m "integration and hugegraph"
+```
+
+CI runs the integration job against the `hugegraph/hugegraph:1.7.0` image. `HUGEGRAPH_GRAPHSPACE` is also read when you need a non-default space.
+
+The source code and tests are under `hugegraph-python-client/src/pyhugegraph/` and `hugegraph-python-client/src/tests/`. A runnable example is at `hugegraph-python-client/src/pyhugegraph/example/hugegraph_example.py`.


### PR DESCRIPTION
Syncs the HugeGraph Python client quick start (en and cn) with `apache/hugegraph-ai@main` at version 1.7.0. Every change below traces to a file on `main`.

## Note on the PyPI package name

`hugegraph-python` on PyPI is the Apache-published distribution (latest 1.5.0, author `Apache HugeGraph Contributors <dev@hugegraph.apache.org>`). `hugegraph-python-client` on PyPI is an unrelated empty 0.1.1 placeholder with no author, license or project URLs. The repo declares the distribution as `hugegraph-python-client` 1.7.0, but nothing has shipped under that name. The install command is therefore left as `hugegraph-python` and the naming and version gap is documented on the page, rather than "fixed" into a command that does not work.

| Page | Wrong | Changed to | Source |
|---|---|---|---|
| en + cn | `uv sync` from the repo root installs the client | `uv sync --extra python-client`; the client is a workspace member reached only through that extra | `pyproject.toml:40,93-97`, `.github/workflows/hugegraph-python-client.yml:52` |
| en + cn | Requirements said only "An accessible HugeGraph Server" | HugeGraph Server 1.5.0 or later; the client raises `RuntimeError` on older servers and points at client v1.3.x | `hugegraph-python-client/src/pyhugegraph/utils/huge_config.py:66-71` |
| en + cn | "Python 3.9 or later", no workspace caveat | 3.9 for the client itself, 3.10+ for the HugeGraph-AI workspace, CI on 3.10 and 3.11 | `hugegraph-python-client/pyproject.toml:27`, `pyproject.toml:27`, `.github/workflows/hugegraph-python-client.yml:22` |
| en + cn | Install section stated the PyPI name with no context | Kept `hugegraph-python` (verified correct) and noted that the in-repo distribution is `hugegraph-python-client` 1.7.0 and the PyPI release lags | `hugegraph-python-client/pyproject.toml:19-20`, `hugegraph-python-client/README.md:15-16` |
| en + cn | No runtime dependency list | `decorator`, `requests`, `setuptools`, `urllib3`, `rich` | `hugegraph-python-client/pyproject.toml:29-36` |
| en + cn | Example passed `"127.0.0.1:8080"` positionally with no parameter reference | Full signature `PyHugeClient(url, graph, user, pwd, graphspace=None, timeout=None)` plus a parameter table, including `timeout` defaulting to `(0.5, 15.0)` | `hugegraph-python-client/src/pyhugegraph/client.py:50-59` |
| en + cn | "If GraphSpace is disabled, omit `graphspace`; the default space is usually `DEFAULT`" | Actual resolution: probes `GET {url}/versions`; server < 1.5.0 raises, > 1.5.0 auto-sets `DEFAULT` and enables the mode, exactly 1.5.0 stays off, network failure stays off; plus the resulting URL prefix | `.../utils/huge_config.py:39-92`, `.../utils/huge_requests.py:113-121` |
| en + cn | No list of the client's managers | Table of the 10 accessors, plus a note that `RankManager`, `RebuildManager` and `ServicesManager` ship but are not exposed | `.../client.py:61-99`, `.../api/rank.py:27`, `.../api/rebuild.py:23`, `.../api/services.py:24` |
| en + cn | No schema-builder documentation | Added the fluent builders for property keys, vertex labels, edge labels and index labels | `.../api/schema_manage/property_key.py:30-180`, `vertex_label.py:28-138`, `edge_label.py:30-161`, `index_label.py:30-100` |
| en + cn | Schema query section omitted `getSchema`, the single-item getters and `getRelations` | Added them, including the `Person--ActedIn-->Movie` output shape | `.../api/schema.py:65-132` |
| en + cn | Update and delete section only showed `appendVertex`, `removeEdgeById`, `removeVertexById` | Added `eliminateVertex`, `appendEdge`, `eliminateEdge`, the `VertexData` and `EdgeData` fields, and the vertex-id type rules | `.../api/graph.py:50-62,140-158`, `.../structure/vertex_data.py:27-39`, `.../structure/edge_data.py:31-59`, `.../utils/id_format.py:27-47` |
| en + cn | No batch write section | `addVertices` takes `(label, properties)` pairs, `addEdges` takes 6-tuples; both return id-only objects | `.../api/graph.py:41-48,122-138` |
| en + cn | No paging or conditional query section | `getVertexByPage` returns `(items, next_page)`, `getVertexByCondition`, `getEdgeByPage` (direction required with `vertex_id`), `getVerticesById`, `getEdgesById` | `.../api/graph.py:70-104,166-221` |
| en + cn | Gremlin section did not state alias binding or the failure mode | `exec` binds `graph` and `g` from the graph name and GraphSpace, returns `result`, raises `ResponseParseError` on a malformed payload | `.../api/gremlin.py:26,30-56` |
| en + cn | No traverser section at all | Added `TraverserManager` with the snake_case methods and the POST-body variants | `.../api/traverser.py:31-250` |
| en + cn | No graph variables section | `set`, `get`, `all`, `remove` | `.../api/variable.py:24-39` |
| en + cn | No async task section | `list_tasks(status, limit)`, `get_task`, `cancel_task`, `delete_task` | `.../api/task.py:22-42` |
| en + cn | No metrics, graphs info or version section | Nine metrics getters, `get_all_graphs` / `get_version` / `get_graph_info` / `get_graph_config` / `clear_graph_all_data`, and `version()` | `.../api/metric.py:22-57`, `.../api/graphs.py:25-62`, `.../api/version.py:22-25` |
| en + cn | No auth section | `AuthManager` with graphspace-scoped users, targets, belongs and accesses, server-level groups, and the `ValueError` raised on 1.7.0+ when no graphspace resolves | `.../api/auth.py:25-209`, `.../utils/huge_router.py:134-149` |
| en + cn | No mention that camelCase methods have snake_case aliases | Added a naming section noting camelCase is marked deprecated in the debug log | `.../api/common.py:85-101` |
| en + cn | No error handling section | Exception table (401 to `NotAuthorizedError`, 404 to `NotFoundError`, other non-2xx to `ServerError`) plus the credential redaction behaviour | `.../utils/exceptions.py:19-76`, `.../utils/util.py:66-95,166-206` |
| en + cn | Retry and timeout behaviour undocumented | 3 retries with 0.1 backoff on 500, 502 and 504 | `.../utils/huge_requests.py:36-39,63-72` |
| en + cn | Development section only had the style script | Added the CI pytest invocations, the `HUGEGRAPH_*` env vars and the `hugegraph/hugegraph:1.7.0` CI image | `.github/workflows/hugegraph-python-client.yml:56,74,111-119`, `hugegraph-python-client/src/tests/client_utils.py:39-43` |
| en + cn | No pointer to a runnable example | Linked `hugegraph-python-client/src/pyhugegraph/example/hugegraph_example.py` | `.../example/hugegraph_example.py:21-58` |

## Upstream defects found while reading the code

Not fixed here, they belong in `apache/hugegraph-ai`. `hugegraph-python-client/README.md` is stale in ways the doc pages no longer are:

- `README.md:48` calls `PyHugeClient("127.0.0.1", "8080", user=..., pwd=..., graph=..., graphspace=...)`, which raises `TypeError` against the current signature, since `graph` is the second positional parameter (`src/pyhugegraph/client.py:50-59`).
- `README.md:124-160` uses `addVertex('person').property(...).create()`, `updateVertex(...)`, `deleteVertex(...)` and `deleteEdge(...)`, none of which exist on `GraphManager` (`src/pyhugegraph/api/graph.py`).

## Correction for a page this PR does not own

`content/en/docs/quickstart/client/hugegraph-client.md:11` and its `cn` counterpart link the Python client to the GitHub source tree, `https://github.com/apache/hugegraph-ai/tree/main/hugegraph-python-client`, while the sibling Go client link is an internal doc link. It should point at `/docs/quickstart/client/hugegraph-client-python` instead, now that this page is the fuller reference. Left for the owner of that page.
