### PR TITLE
doc(server): sync pd with master

### DIFF
--- a/content/cn/docs/quickstart/hugegraph/hugegraph-pd.md
+++ b/content/cn/docs/quickstart/hugegraph/hugegraph-pd.md
@@ -8,6 +8,16 @@ weight: 2
 
 HugeGraph-PD（Placement Driver）是 HugeGraph 分布式版本的元数据管理组件，负责管理图数据的分布和存储节点的协调。它在分布式 HugeGraph 中扮演着核心角色，维护集群状态并协调 HugeGraph-Store 存储节点。
 
+PD 将集群元数据保存在 `pd.data-path` 下的内嵌 RocksDB 中，并通过 Raft 在各 PD 节点之间复制，因此 3 节点或 5 节点的 PD 集群在少数节点宕机时仍可继续提供服务。在此基础上，PD 还负责注册和激活 Store 节点、分配与再平衡分区、跟踪 Store 心跳，并响应来自 Store 和 Server 的服务发现请求。
+
+PD 监听三个端口：
+
+| 端口 | 默认值 | 配置项 | 使用方 |
+|------|--------|--------|--------|
+| gRPC | `8686` | `grpc.port` | Store 和 Server 客户端 |
+| REST | `8620` | `server.port` | 管理接口、健康检查、监控指标 |
+| Raft | `8610` | `raft.address` | 仅其他 PD 节点 |
+
 ### 2 依赖
 
 #### 2.1 前置条件
@@ -44,10 +54,19 @@ git clone https://github.com/apache/hugegraph.git
 cd hugegraph
 mvn clean install -DskipTests=true
 
-# 3. 编译成功后，PD 目录和完整发布包分别位于
-#    hugegraph-pd/apache-hugegraph-pd-{version}
-#    target/apache-hugegraph-{version}.tar.gz
+# 3. 编译成功后，PD 目录和发布包分别位于
+#    hugegraph-pd/apache-hugegraph-pd-{version}          （解压后的 PD 发布目录）
+#    hugegraph-pd/apache-hugegraph-pd-{version}.tar.gz   （仅含 PD 的发布包，只在 Linux 构建机上生成）
+#    target/apache-hugegraph-{version}.tar.gz            （PD + Store + Server 的完整发布包）
 ```
+
+只编译 PD 发布包及其依赖模块：
+
+```bash
+mvn clean package -pl hugegraph-pd/hg-pd-dist -am -DskipTests
+```
+
+解压后的发布目录只包含三个子目录：`bin`（启停脚本）、`conf`（`application.yml`、`application.yml.template`、`log4j2.xml`、`verify-license.json`）和 `lib`（`hg-pd-service` jar 包）。
 
 #### 3.3 Docker 部署
 
@@ -61,6 +80,8 @@ cd hugegraph/docker
 # 注意版本号请随时保持更新 → 1.x.0
 HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
+
+单 PD、单 Store、单 Server 的最小拓扑对应 `docker-compose-hstore.yml`。
 
 通过 `docker run` 运行单个 PD 节点时，通过环境变量提供配置：
 
@@ -80,37 +101,57 @@ docker run -d \
 
 **环境变量参考：**
 
-| 变量 | 必填 | 默认值 | 描述 |
-|------|------|--------|------|
-| `HG_PD_GRPC_HOST` | 是 | — | 本节点的 gRPC 主机名/IP（Docker 中使用 `pd0`，裸机使用 `192.168.1.10`） |
-| `HG_PD_RAFT_ADDRESS` | 是 | — | 本节点的 Raft 地址（如 `pd0:8610`） |
-| `HG_PD_RAFT_PEERS_LIST` | 是 | — | 所有 PD 节点的 Raft 地址（如 `pd0:8610,pd1:8610,pd2:8610`） |
-| `HG_PD_INITIAL_STORE_LIST` | 是 | — | 预期的 Store gRPC 地址（如 `store0:8500,store1:8500,store2:8500`） |
-| `HG_PD_GRPC_PORT` | 否 | `8686` | gRPC 服务端口 |
-| `HG_PD_REST_PORT` | 否 | `8620` | REST API 端口 |
-| `HG_PD_DATA_PATH` | 否 | `/hugegraph-pd/pd_data` | 元数据存储路径 |
-| `HG_PD_INITIAL_STORE_COUNT` | 否 | `1` | 集群可用所需的最小 Store 数量 |
+| 变量 | 必填 | 默认值 | 对应配置项 | 描述 |
+|------|------|--------|------------|------|
+| `HG_PD_GRPC_HOST` | 是 | 无 | `grpc.host` | 本节点的 gRPC 主机名/IP（Docker 中使用 `pd0`，裸机使用 `192.168.1.10`） |
+| `HG_PD_RAFT_ADDRESS` | 是 | 无 | `raft.address` | 本节点的 Raft 地址（如 `pd0:8610`） |
+| `HG_PD_RAFT_PEERS_LIST` | 是 | 无 | `raft.peers-list` | 所有 PD 节点的 Raft 地址（如 `pd0:8610,pd1:8610,pd2:8610`） |
+| `HG_PD_INITIAL_STORE_LIST` | 是 | 无 | `pd.initial-store-list` | 预期的 Store gRPC 地址（如 `store0:8500,store1:8500,store2:8500`） |
+| `HG_PD_GRPC_PORT` | 否 | `8686` | `grpc.port` | gRPC 服务端口 |
+| `HG_PD_REST_PORT` | 否 | `8620` | `server.port` | REST API 端口 |
+| `HG_PD_DATA_PATH` | 否 | `/hugegraph-pd/pd_data` | `pd.data-path` | 元数据存储路径 |
+| `HG_PD_INITIAL_STORE_COUNT` | 否 | `1` | `pd.initial-store-count` | 集群可用所需的最小 Store 数量 |
+
+缺少上述四个必填变量中的任意一个时，entrypoint 会拒绝启动。它把这些值转换成 `SPRING_APPLICATION_JSON` 覆盖项，因此无需修改镜像内的 `conf/application.yml`；未被 `HG_PD_*` 变量覆盖的配置项仍沿用该文件中的值。`JAVA_OPTS` 会透传给 JVM。
 
 > **注意**：在 Docker 桥接网络中，`HG_PD_GRPC_HOST` 和 `HG_PD_RAFT_ADDRESS` 应使用容器主机名（如 `pd0`）而非 IP 地址。
 
 > **已弃用的别名**：`GRPC_HOST`、`RAFT_ADDRESS`、`RAFT_PEERS`、`PD_INITIAL_STORE_LIST` 仍可使用，但会输出弃用警告。新部署请使用 `HG_PD_*` 名称。
 
-运行时日志可通过 `docker logs <container-name>`（如 `docker logs hg-pd0`）直接查看，无需进入容器。
+镜像内置 `HEALTHCHECK`，每 15 秒探测 `8620` 端口上的 `GET /v1/health`，启动宽限期 90 秒、重试 3 次，因此 `docker ps` 能反映真实的 PD 健康状态。entrypoint 以 `-d false` 调用启动脚本，容器进程就是 Java 进程本身，Java 退出时容器随之退出并触发 Docker 的重启策略。镜像还设置了 `STDOUT_MODE=true`，因此运行时日志可通过 `docker logs <container-name>`（如 `docker logs hg-pd0`）直接查看，无需进入容器。
 
 完整的集群部署指南请参阅 [docker/README.md](https://github.com/apache/hugegraph/blob/master/docker/README.md)。
 
 ### 4 配置
 
-PD 的主要配置文件为 `conf/application.yml`，以下是关键配置项：
+PD 的主要配置文件为 `conf/application.yml`，以下是发布包中自带的内容：
 
 ```yaml
 spring:
   application:
     name: hugegraph-pd
 
+management:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+logging:
+  config: 'file:./conf/log4j2.xml'
+
+license:
+  verify-path: ./conf/verify-license.json
+  license-path: ./conf/hugegraph.license
+
 grpc:
   # 集群模式下的 gRPC 端口
   port: 8686
+  # 部署时需改为本机实际的 IPv4 地址
   host: 127.0.0.1
 
 server:
@@ -128,7 +169,7 @@ pd:
   initial-store-list: 127.0.0.1:8500
 
 raft:
-  # 集群模式
+  # 本节点的 raft 地址
   address: 127.0.0.1:8610
   # 集群中所有 PD 节点的 raft 地址
   peers-list: 127.0.0.1:8610
@@ -142,7 +183,6 @@ store:
   monitor_data_interval: 1 minute
   # 监控数据的保留时间
   monitor_data_retention: 1 day
-  initial-store-count: 1
 
 partition:
   # 默认每个分区副本数
@@ -151,7 +191,173 @@ partition:
   store-max-shard-count: 12
 ```
 
-对于多节点部署，需要修改各节点的端口和地址配置，确保各节点之间能够正常通信。
+`conf/application.yml.template` 是另一份带占位符（`$GRPC_PORT$`、`$RAFT_ADDRESS$` 等）的副本，供自动生成配置的部署工具使用，PD 本身不读取它。启动脚本通过 `-Dspring.config.location` 指定的始终是 `conf/application.yml`。
+
+#### 4.1 配置项参考
+
+`conf/application.yml` 中未出现的配置项会回退到下表的内置默认值；没有内置默认值的配置项必须存在，否则 PD 无法启动。
+
+**gRPC 与 REST**
+
+| 配置项 | 发布包中的值 | 内置默认值 | 描述 |
+|--------|--------------|------------|------|
+| `grpc.host` | `127.0.0.1` | 无，必填 | 本 PD 对外公布的 gRPC 地址。Store 和 Server 会连到这个地址，因此分布式部署时必须填可访问的 IPv4 地址或主机名，不能用 `127.0.0.1` 或 `0.0.0.0`。 |
+| `grpc.port` | `8686` | 无，必填 | gRPC 端口。 |
+| `server.port` | `8620` | 无，必填 | REST API 端口，同时也是 Raft 成员信息中公布的 REST 端口。 |
+
+`application.yml.template` 中还有 `grpc.netty-server.max-inbound-message-size: 100MB`，但 PD 在代码中把 gRPC 服务端的入站消息上限固定为 1 GB，该配置项实际不生效。
+
+**Raft**
+
+| 配置项 | 发布包中的值 | 内置默认值 | 描述 |
+|--------|--------------|------------|------|
+| `raft.address` | `127.0.0.1:8610` | 无，必填 | 本节点的 Raft 地址，格式为 `host:port`。每个节点必须不同，且必须出现在 `raft.peers-list` 中。 |
+| `raft.peers-list` | `127.0.0.1:8610` | 无，必填 | 逗号分隔的全部 PD 节点 Raft 地址（含本节点）。所有节点上必须完全一致。 |
+| `raft.enable` | 未设置 | `true` | 为 true 时元数据写入经过 Raft 状态机；为 false 时 PD 直接写本地存储，不做复制。 |
+| `raft.ip-whitelist.enabled` | 未设置 | `true` | 为 true 时 Raft RPC 端口只接受由 `raft.peers-list` 解析出的地址的连接，其他连接会被断开并记录 `Blocked connection from <ip>`。peer 列表变更时白名单会重新解析，但主机名不变而 IP 变化的情况（例如容器重启）仍需重启 PD。 |
+| `raft.snapshotInterval` | 未设置 | `300` | Raft 快照生成间隔（秒）。 |
+| `raft.rpc-timeout` | 未设置 | `10000` | Raft RPC 的连接、请求和安装快照超时时间（毫秒）。 |
+
+**PD 核心**
+
+| 配置项 | 发布包中的值 | 内置默认值 | 描述 |
+|--------|--------------|------------|------|
+| `pd.data-path` | `./pd_data` | 无，必填 | 元数据目录。`rocksdb/` 子目录存放 RocksDB 数据，`pd_raft/` 子目录存放 Raft 日志、元信息和快照。 |
+| `pd.patrol-interval` | `1800` | `300` | 巡检周期（秒）。巡检会检查各 Store 上的分区健康状况并平衡分区数量。 |
+| `pd.initial-store-count` | `1` | `3` | 活跃 Store 节点的最小数量。低于该值时集群状态变为 `Cluster_Not_Ready`，整个集群视为不可用。建议设为实际部署的 Store 数量。 |
+| `pd.initial-store-list` | `127.0.0.1:8500` | 空 | 逗号分隔的 Store gRPC 地址（`ip:port`），列表中的 Store 注册后自动激活。条目也可以带分组 id，写作 `store_address/group_id`。 |
+| `pd.cluster_id` | 未设置 | `1` | 集群 id，用于区分不同的 PD 集群。 |
+
+**Store 管理**
+
+| 配置项 | 发布包中的值 | 内置默认值 | 描述 |
+|--------|--------------|------------|------|
+| `store.keepAlive-timeout` | 未设置 | `300` | 心跳超时时间（秒）。超过该时间未收到心跳，Store 视为临时不可用，其分区 leader 转移到其他副本。 |
+| `store.max-down-time` | `172800` | `1800` | 超过该时间（秒）后 Store 视为永久不可用，其副本重新分配到其他机器。 |
+| `store.monitor_data_enabled` | `true` | `false` | 是否持久化 Store 监控采样数据。 |
+| `store.monitor_data_interval` | `1 minute` | `1 minute` | 采样间隔，格式为 `<数字> <单位>`，单位为 `second`、`minute`、`hour`、`day`、`month`、`year` 之一；省略数字时按 1 计。 |
+| `store.monitor_data_retention` | `1 day` | `1 day` | 监控数据保留时长，格式同上。 |
+
+**分区**
+
+| 配置项 | 发布包中的值 | 内置默认值 | 描述 |
+|--------|--------------|------------|------|
+| `partition.default-shard-count` | `1` | `3` | 每个分区的副本数。生产集群建议设为 `3`。 |
+| `partition.store-max-shard-count` | `12` | `24` | 单个 Store 最多承载的分区副本数。 |
+
+初始分区数由这两个配置项和 `pd.initial-store-list` 的长度推导得出：
+
+```text
+初始分区数 = Store 数量 * partition.store-max-shard-count / partition.default-shard-count
+```
+
+**服务发现、License 与监控**
+
+| 配置项 | 发布包中的值 | 内置默认值 | 描述 |
+|--------|--------------|------------|------|
+| `discovery.heartbeat-try-count` | 未设置 | `3` | 客户端注册后连续丢失多少次心跳就删除其注册信息。 |
+| `license.verify-path` | `./conf/verify-license.json` | 无，必填 | License 校验描述文件路径，由 `/v1/license` 接口读取。 |
+| `license.license-path` | `./conf/hugegraph.license` | 无，必填 | License 文件路径。发布包只带 `verify-license.json`，不带 license 文件，因此在提供该文件之前 license 接口会返回错误。 |
+| `auth.secret-key` | 未设置 | 内置常量 | 用于给内部客户端签发 PD token 的 HS256 密钥。 |
+| `management.metrics.export.prometheus.enabled` | `true` | Spring Boot 默认值 | 是否暴露 `/actuator/prometheus`。 |
+| `management.endpoints.web.exposure.include` | `"*"` | Spring Boot 默认值 | 需要暴露的 actuator 端点。 |
+| `logging.config` | `file:./conf/log4j2.xml` | 无 | Log4j2 配置文件，会写出 `logs/hugegraph-pd.log`、`logs/hugegraph-pd_raft.log` 和 `logs/audit-hugegraph-pd.log`。 |
+
+**线程池**
+
+| 配置项 | 内置默认值 | 描述 |
+|--------|------------|------|
+| `thread.pool.grpc.core` | `600` | 处理 gRPC 请求的线程池核心线程数。 |
+| `thread.pool.grpc.max` | `1000` | 该线程池的最大线程数。 |
+| `thread.pool.grpc.queue` | 无上限 | 该线程池的队列容量。 |
+| `job.uninterruptibleThreadPool.core` | `0` | 元数据后台任务线程池的核心线程数。小于等于 0 时取可用处理器数的一半。 |
+| `job.uninterruptibleThreadPool.max` | `256` | 该线程池的最大线程数。 |
+| `job.uninterruptibleThreadPool.queue` | 无上限 | 该线程池的队列容量。 |
+
+#### 4.2 单节点配置
+
+发布包自带的 `conf/application.yml` 本身就是一份可用的单节点配置，适用于开发和测试：单节点 PD 不存在 Raft 多数派可失，`partition.default-shard-count: 1` 表示每个分区只有一个副本。
+
+```yaml
+grpc:
+  host: 127.0.0.1
+  port: 8686
+server:
+  port: 8620
+raft:
+  address: 127.0.0.1:8610
+  peers-list: 127.0.0.1:8610
+pd:
+  data-path: ./pd_data
+  initial-store-count: 1
+  initial-store-list: 127.0.0.1:8500
+partition:
+  default-shard-count: 1
+```
+
+#### 4.3 三节点集群配置
+
+生产环境请部署 3 个或 5 个 PD 节点，节点数取奇数以保证 Raft 总能形成多数派。3 节点集群可容忍 1 个节点故障。`raft.peers-list` 必须列出全部节点，并且在所有节点上逐字节一致；`grpc.host` 和 `raft.address` 每个节点各不相同。
+
+节点 1（`192.168.1.10`）：
+
+```yaml
+grpc:
+  host: 192.168.1.10
+  port: 8686
+server:
+  port: 8620
+raft:
+  address: 192.168.1.10:8610
+  peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
+pd:
+  data-path: /data/pd
+  initial-store-count: 3
+  initial-store-list: 192.168.1.20:8500,192.168.1.21:8500,192.168.1.22:8500
+partition:
+  default-shard-count: 3
+```
+
+节点 2（`192.168.1.11`）和节点 3（`192.168.1.12`）使用同一份配置，只把 `grpc.host` 和 `raft.address` 换成自己的地址：
+
+```yaml
+# 节点 2
+grpc:
+  host: 192.168.1.11
+raft:
+  address: 192.168.1.11:8610
+  peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
+
+# 节点 3
+grpc:
+  host: 192.168.1.12
+raft:
+  address: 192.168.1.12:8610
+  peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
+```
+
+若要在同一台机器上启动 3 个 PD 节点做测试，需为每个节点分别指定 `pd.data-path` 和各自的端口，例如 raft 端口 `8610/8611/8612`、gRPC 端口 `8686/8687/8688`、REST 端口 `8620/8621/8622`。
+
+在 Docker 桥接网络中，同样的配置来自环境变量，并使用容器主机名而非 IP 地址：
+
+```yaml
+# pd0
+HG_PD_GRPC_HOST: pd0
+HG_PD_RAFT_ADDRESS: pd0:8610
+HG_PD_RAFT_PEERS_LIST: pd0:8610,pd1:8610,pd2:8610
+HG_PD_INITIAL_STORE_LIST: store0:8500,store1:8500,store2:8500
+HG_PD_INITIAL_STORE_COUNT: 3
+
+# pd1
+HG_PD_GRPC_HOST: pd1
+HG_PD_RAFT_ADDRESS: pd1:8610
+HG_PD_RAFT_PEERS_LIST: pd0:8610,pd1:8610,pd2:8610
+
+# pd2
+HG_PD_GRPC_HOST: pd2
+HG_PD_RAFT_ADDRESS: pd2:8610
+HG_PD_RAFT_PEERS_LIST: pd0:8610,pd1:8610,pd2:8610
+```
 
 ### 5 启动与停止
 
@@ -163,16 +369,31 @@ partition:
 ./bin/start-hugegraph-pd.sh
 ```
 
-启动脚本支持 `-d` 参数控制守护进程模式：
+脚本要求 `PATH` 或 `JAVA_HOME` 中有 11 及以上版本的 JDK；如果发现已有 Java 进程在使用本安装目录的 `conf` 目录，脚本会直接退出，不做任何事。
+
+支持的参数：
+
+| 参数 | 取值 | 默认值 | 描述 |
+|------|------|--------|------|
+| `-d` | `true`、`false` | `true` | 守护进程模式，详见下文。 |
+| `-g` | `zgc`、`ZGC` | 不设置 | 垃圾回收器。不带该参数即使用默认的 G1GC；填其他值（包括 `g1`）会导致启动中止。 |
+| `-j` | JVM 参数 | 空 | 额外的 JVM 参数，例如 `-j "-Xmx8g -Xms8g"`。 |
+| `-y` | `true`、`false` | `false` | 挂载 OpenTelemetry Java agent。首次使用时会把 agent 下载到 `plugins/` 并校验 MD5，trace 通过 gRPC 上报到 `http://127.0.0.1:4317`。 |
+
+`-d` 参数控制守护进程模式：
 
 - `-d true`（默认）：以后台守护进程方式运行，脚本立即返回。
-- `-d false`：以前台模式运行——脚本通过 `exec` 替换为 Java 进程，容器/进程管理器的进程即为 Java 本身。在 Docker 或进程管理器（systemd、supervisord）下运行时请使用此参数，以便在崩溃时自动检测并重启服务。
+- `-d false`：以前台模式运行，脚本通过 `exec` 替换为 Java 进程，容器/进程管理器的进程即为 Java 本身。在 Docker 或进程管理器（systemd、supervisord）下运行时请使用此参数，以便在崩溃时自动检测并重启服务。
+
+每个参数都有对应的环境变量：`DAEMON`、`GC_OPTION`、`USER_OPTION` 和 `OPEN_TELEMETRY`。设置 `JAVA_OPTIONS` 会完全替换脚本计算出的堆参数，否则脚本会根据可用内存在 512 MB 到 32 GB 之间选择堆大小。设置 `STDOUT_MODE=true` 时 JVM 输出保留在 stdout，不再重定向到 `logs/hugegraph-pd-stdout.log`，Docker 镜像正是这样做的。
 
 启动成功后，可以在 `logs/hugegraph-pd-stdout.log` 中看到类似以下的日志：
 
 ```
 YYYY-mm-dd xx:xx:xx [main] [INFO] o.a.h.p.b.HugePDServer - Started HugePDServer in x.xxx seconds (JVM running for x.xxx)
 ```
+
+进程号会写入 `bin/pid`。
 
 #### 5.2 停止 PD
 
@@ -182,9 +403,47 @@ YYYY-mm-dd xx:xx:xx [main] [INFO] o.a.h.p.b.HugePDServer - Started HugePDServer 
 ./bin/stop-hugegraph-pd.sh
 ```
 
-### 6 验证
+脚本读取 `bin/pid`，向该进程发送终止信号，最多等待 30 秒直到进程退出，然后删除 pid 文件。如果 `bin/pid` 不存在，脚本会提示并正常退出。
 
-确认 PD 服务是否正常运行：
+### 6 分布式集群的启动顺序
+
+请按以下顺序启动各组件：
+
+1. **全部 PD 节点**。它们组成 Raft 组并选出 leader。等到每个节点都能响应 `GET /v1/health` 再继续。
+2. **全部 Store 节点**。每个 Store 通过 gRPC 向 PD 注册，PD 会自动激活 `pd.initial-store-list` 中列出的 Store。等到 `GET /v1/stores` 中每个 Store 的 `state` 都是 `Up` 再继续。
+3. **全部 Server 节点**。Server 读取 `pd.peers`，并依赖 PD 报告至少有一个存活的 Store 才能完成分区分配。
+
+Docker Compose 的各个拓扑正是这样编排的：Store 容器通过 `depends_on` 加 `condition: service_healthy` 等待 PD 的 `/v1/health` 健康检查，Server 容器以同样方式等待 Store 的健康检查，Server 的 entrypoint 还会轮询 PD 的 `/v1/stores`，直到有 Store 报告 `Up` 才启动 HugeGraph。
+
+停止时顺序相反：先停 Server，再停 Store，最后停 PD。
+
+### 7 验证
+
+#### 7.1 REST API 认证
+
+除 `/actuator/*`、`/v1/health` 和 `/v1/prom/targets/*` 之外，PD 的所有 REST 路径都要求带 HTTP Basic `Authorization` 头，且用户名必须是内部服务名 `hg`、`store`、`hubble`、`vermeer` 之一。不带该头的请求会得到：
+
+```json
+{"status": -1, "error": "Unauthorized!"}
+```
+
+目前不校验密码，任意值均可。Server 自带的 `bin/wait-storage.sh` 使用 `store:admin`，并支持用 `PD_AUTH_USER` 和 `PD_AUTH_PASSWORD` 覆盖，因此下面的示例使用同样的凭据：
+
+```bash
+curl -u store:admin http://localhost:8620/v1/stores
+```
+
+> **警告**：该校验只用于区分 HugeGraph 自身组件与其他流量。请勿把 PD 的 REST 或 gRPC 端口暴露到不可信网络，应通过防火墙规则或安全组加以限制，并保持 `raft.ip-whitelist.enabled` 开启，使 Raft 端口只接受配置中的 peer。
+
+#### 7.2 健康检查
+
+`GET /v1/health` 不需要凭据，Docker 健康检查用的就是它。它返回 `200` 且响应体为空：
+
+```bash
+curl -i http://localhost:8620/v1/health
+```
+
+Spring Boot actuator 端点同样可用，输出更直观：
 
 ```bash
 curl http://localhost:8620/actuator/health
@@ -192,10 +451,120 @@ curl http://localhost:8620/actuator/health
 
 如果返回 `{"status":"UP"}`，则表示 PD 服务已成功启动。
 
+#### 7.3 集群与成员状态
+
+查看 PD 成员以及当前的 Raft leader：
+
+```bash
+curl -u store:admin http://localhost:8620/v1/members
+```
+
+响应中包含 `pdList`、选出的 `pdLeader`、`numOfService`、`numOfNormalService` 和 `stateCountMap`。健康的 3 节点 PD 集群中，`numOfService` 和 `numOfNormalService` 都应为 `3`，且恰好有一个成员的 `role` 为 `Leader`。
+
+`GET /v1/cluster` 在成员列表之外还返回 Store 列表、图列表和集群整体状态；`GET /` 返回一份简要汇总（leader 地址、集群状态、成员数、Store 数、图数量、分区数）。
+
+#### 7.4 Store 状态
+
 也可以通过 PD API 查看 Store 节点状态：
 
 ```bash
-curl http://localhost:8620/v1/stores
+curl -u store:admin http://localhost:8620/v1/stores
 ```
 
-如果响应中 `state` 为 `Up`，说明对应的 Store 节点运行正常。在一个健康的 3 节点部署中，`storeId` 列表应包含 3 个 ID，且 `stateCountMap.Up`、`numOfService` 和 `numOfNormalService` 都应为 `3`。
+如果响应中 `state` 为 `Up`，说明对应的 Store 节点运行正常。下面的示例只有一个 Store 节点。在一个健康的 3 节点部署中，`storeId` 列表应包含 3 个 ID，且 `stateCountMap.Up`、`numOfService` 和 `numOfNormalService` 都应为 `3`。
+
+```javascript
+{
+  "message": "OK",
+  "data": {
+    "stores": [
+      {
+        "storeId": 8319292642220586694,
+        "address": "127.0.0.1:8500",
+        "raftAddress": "127.0.0.1:8510",
+        "version": "",
+        "state": "Up",
+        "deployPath": "/Users/{your_user_name}/hugegraph/apache-hugegraph-incubating-1.7.0/apache-hugegraph-store-incubating-1.7.0/lib/hg-store-node-1.7.0.jar",
+        "dataPath": "./storage",
+        "startTimeStamp": 1754027127969,
+        "registedTimeStamp": 1754027127969,
+        "lastHeartBeat": 1754027909444,
+        "capacity": 494384795648,
+        "available": 346535829504,
+        "partitionCount": 0,
+        "graphSize": 0,
+        "keyCount": 0,
+        "leaderCount": 0,
+        "serviceName": "127.0.0.1:8500-store",
+        "serviceVersion": "",
+        "serviceCreatedTimeStamp": 1754027127000,
+        "partitions": []
+      }
+    ],
+    "stateCountMap": {
+      "Up": 1
+    },
+    "numOfService": 1,
+    "numOfNormalService": 1
+  },
+  "status": 0
+}
+```
+
+#### 7.5 其他 REST 接口
+
+下表中的路径均相对于 `http://<pd-host>:8620`，除注明外都需要 7.1 中的 Basic 认证头。
+
+| 方法与路径 | 描述 |
+|------------|------|
+| `GET /` | 集群简要统计：leader、状态、成员数、Store 数、图数量、分区数 |
+| `GET /v1/health` | 健康检查，无需认证 |
+| `GET /v1/cluster` | 集群完整统计：PD 成员、Store、图、分区 |
+| `GET /v1/members` | PD 成员列表，含角色和选出的 leader |
+| `POST /v1/members/change` | 修改 Raft peer 列表，请求体 `{"peerList": "..."}` |
+| `GET /v1/stores` | 已注册的 Store 节点及其状态和统计信息 |
+| `GET /v1/store/{storeId}` | 单个 Store 节点 |
+| `POST /v1/store/{storeId}` | 修改 Store 状态，请求体 `{"storeState": "..."}` |
+| `DELETE /v1/store/{storeId}` | 从集群中移除 Store |
+| `POST /v1/store/log` | Store 状态变更日志，请求体 `{"startTime": "...", "endTime": "..."}` |
+| `GET /v1/storesAndStats` | Store 原始元数据，用于调试 |
+| `GET /v1/store_monitor/{storeId}` | Store 监控采样数据（文本） |
+| `GET /v1/store_monitor/json/{storeId}` | Store 监控采样数据（JSON） |
+| `GET /v1/shards` | 所有分区的所有副本，含 store id、角色、状态和进度 |
+| `GET /v1/shardGroups` | Shard 分组 |
+| `GET /v1/shardGroupsCache` | PD 内存缓存中的 shard 分组 |
+| `GET /v1/shardLeaders` | 按 Store raft 地址分组的分区 leader |
+| `GET /v1/balanceLeaders` | 在各 Store 之间重新平衡分区 leader |
+| `GET /v1/partitions` | 分区列表及其状态和统计信息 |
+| `GET /v1/highLevelPartitions` | 分区列表，含各图的 key 数量和数据大小 |
+| `GET /v1/partitionsAndStats` | 分区原始元数据，用于调试 |
+| `POST /v1/partitions/log` | 分区变更日志，请求体 `{"startTime": "...", "endTime": "..."}` |
+| `GET /v1/resetPartitionState` | 重置所有分区的状态 |
+| `GET /v1/graphs` | 图列表 |
+| `GET /v1/graph/**` | 按名称查询单个图 |
+| `POST /v1/graph/**` | 修改图的分区数，请求体 `{"partitionCount": N}` |
+| `GET /v1/graph/partitionSizeRange` | 集群允许的分区数上下限 |
+| `GET /v1/graph-spaces` | 图空间列表 |
+| `GET /v1/graph-spaces/**` | 单个图空间 |
+| `POST /v1/graph-spaces/**` | 修改图空间 |
+| `POST /v1/registry` | 注册一个服务实例用于服务发现 |
+| `POST /v1/registryInfo` | 查询已注册的实例 |
+| `GET /v1/allInfo` | 所有已注册的实例 |
+| `GET /v1/license` | License 信息 |
+| `GET /v1/license/machineInfo` | License 校验看到的 IP 和 MAC 地址 |
+| `GET /v1/task/patrolStores` | 立即执行 Store 巡检任务 |
+| `GET /v1/task/patrolPartitions` | 立即执行分区巡检任务 |
+| `GET /v1/task/balancePartitions` | 在各 Store 之间重新平衡分区 |
+| `GET /v1/task/splitPartitions` | 立即执行自动分区拆分 |
+| `GET /v1/task/balanceLeaders` | 重新平衡分区 leader |
+| `GET /v1/task/compact` | 让 Store 节点对其分区的 RocksDB 文件做 compaction |
+| `GET /v1/prom/targets/{appName}` | Prometheus 服务发现目标，无需认证 |
+| `GET /v1/prom/targets-all` | 所有应用类型的 Prometheus 目标 |
+| `GET /v1/prom/sd_config` | Prometheus HTTP 服务发现配置 |
+| `GET /actuator/health` | Spring Boot 健康检查，无需认证 |
+| `GET /actuator/metrics` | Spring Boot 监控指标，无需认证 |
+| `GET /actuator/prometheus` | Prometheus 抓取端点，无需认证 |
+
+两个 `log` 接口接受形如 `{"startTime": "...", "endTime": "..."}` 的时间范围，`yyyy-MM-dd HH:mm:ss` 和 `yyyy-MM-dd` 都是可接受的格式。
+
+PD 以 `hg` 前缀注册自己的指标，因此 `/actuator/prometheus` 除标准 JVM 指标外还会暴露 `hg_up`、`hg_graphs`、`hg_stores` 和 `hg_terms`，在存在图之后还会有按图统计的分区和大小指标。

--- a/content/en/docs/quickstart/hugegraph/hugegraph-pd.md
+++ b/content/en/docs/quickstart/hugegraph/hugegraph-pd.md
@@ -8,6 +8,16 @@ weight: 2
 
 HugeGraph-PD (Placement Driver) is the metadata management component of HugeGraph's distributed version, responsible for managing the distribution of graph data and coordinating storage nodes. It plays a central role in distributed HugeGraph, maintaining cluster status and coordinating HugeGraph-Store storage nodes.
 
+PD keeps cluster metadata in an embedded RocksDB store under `pd.data-path` and replicates it across PD nodes with Raft, so a 3-node or 5-node PD cluster keeps serving while a minority of nodes is down. On top of that it registers and activates Store nodes, allocates and rebalances partitions, tracks Store heartbeats, and answers service discovery queries from Store and Server.
+
+PD listens on three ports:
+
+| Port | Default | Configured by | Used by |
+|------|---------|---------------|---------|
+| gRPC | `8686` | `grpc.port` | Store and Server clients |
+| REST | `8620` | `server.port` | Management, health checks, metrics |
+| Raft | `8610` | `raft.address` | The other PD nodes only |
+
 ### 2 Prerequisites
 
 #### 2.1 Requirements
@@ -44,10 +54,19 @@ git clone https://github.com/apache/hugegraph.git
 cd hugegraph
 mvn clean install -DskipTests=true
 
-# 3. After a successful build, the PD directory and complete distribution package are located at
-#    hugegraph-pd/apache-hugegraph-pd-{version}
-#    target/apache-hugegraph-{version}.tar.gz
+# 3. After a successful build, the PD directory and packages are located at
+#    hugegraph-pd/apache-hugegraph-pd-{version}          (unpacked PD distribution)
+#    hugegraph-pd/apache-hugegraph-pd-{version}.tar.gz   (PD only package, Linux build hosts only)
+#    target/apache-hugegraph-{version}.tar.gz            (PD + Store + Server package)
 ```
+
+To build only the PD distribution and the modules it depends on:
+
+```bash
+mvn clean package -pl hugegraph-pd/hg-pd-dist -am -DskipTests
+```
+
+The unpacked distribution contains just three directories: `bin` (start and stop scripts), `conf` (`application.yml`, `application.yml.template`, `log4j2.xml`, `verify-license.json`) and `lib` (the `hg-pd-service` jar).
 
 #### 3.3 Docker Deployment
 
@@ -62,6 +81,8 @@ cd hugegraph/docker
 # Keep the version aligned with the latest release, for example 1.x.0
 HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
+
+A single PD plus a single Store and Server is also available as `docker-compose-hstore.yml`.
 
 To run a single PD node via `docker run`, configuration is provided via environment variables:
 
@@ -81,37 +102,57 @@ docker run -d \
 
 **Environment variable reference:**
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `HG_PD_GRPC_HOST` | Yes | — | This node's hostname/IP for gRPC (e.g. `pd0` in Docker, `192.168.1.10` on bare metal) |
-| `HG_PD_RAFT_ADDRESS` | Yes | — | This node's Raft address (e.g. `pd0:8610`) |
-| `HG_PD_RAFT_PEERS_LIST` | Yes | — | All PD peers (e.g. `pd0:8610,pd1:8610,pd2:8610`) |
-| `HG_PD_INITIAL_STORE_LIST` | Yes | — | Expected store gRPC addresses (e.g. `store0:8500,store1:8500,store2:8500`) |
-| `HG_PD_GRPC_PORT` | No | `8686` | gRPC server port |
-| `HG_PD_REST_PORT` | No | `8620` | REST API port |
-| `HG_PD_DATA_PATH` | No | `/hugegraph-pd/pd_data` | Metadata storage path |
-| `HG_PD_INITIAL_STORE_COUNT` | No | `1` | Minimum stores required for cluster availability |
+| Variable | Required | Default | Maps to | Description |
+|----------|----------|---------|---------|-------------|
+| `HG_PD_GRPC_HOST` | Yes | n/a | `grpc.host` | This node's hostname/IP for gRPC (e.g. `pd0` in Docker, `192.168.1.10` on bare metal) |
+| `HG_PD_RAFT_ADDRESS` | Yes | n/a | `raft.address` | This node's Raft address (e.g. `pd0:8610`) |
+| `HG_PD_RAFT_PEERS_LIST` | Yes | n/a | `raft.peers-list` | All PD peers (e.g. `pd0:8610,pd1:8610,pd2:8610`) |
+| `HG_PD_INITIAL_STORE_LIST` | Yes | n/a | `pd.initial-store-list` | Expected store gRPC addresses (e.g. `store0:8500,store1:8500,store2:8500`) |
+| `HG_PD_GRPC_PORT` | No | `8686` | `grpc.port` | gRPC server port |
+| `HG_PD_REST_PORT` | No | `8620` | `server.port` | REST API port |
+| `HG_PD_DATA_PATH` | No | `/hugegraph-pd/pd_data` | `pd.data-path` | Metadata storage path |
+| `HG_PD_INITIAL_STORE_COUNT` | No | `1` | `pd.initial-store-count` | Minimum stores required for cluster availability |
+
+The entrypoint refuses to start if any of the four required variables is missing, and it turns the values above into a `SPRING_APPLICATION_JSON` override, so the packaged `conf/application.yml` does not need editing. Any key not covered by an `HG_PD_*` variable keeps the value from that file. `JAVA_OPTS` is passed through to the JVM.
 
 > **Note**: In Docker bridge networking, use container hostnames (e.g. `pd0`) for `HG_PD_GRPC_HOST` and `HG_PD_RAFT_ADDRESS` instead of IP addresses.
 
 > **Deprecated aliases**: `GRPC_HOST`, `RAFT_ADDRESS`, `RAFT_PEERS`, `PD_INITIAL_STORE_LIST` still work but log a deprecation warning. Use the `HG_PD_*` names for new deployments.
 
-To view runtime logs for a running PD container use `docker logs <container-name>` (e.g. `docker logs hg-pd0`).
+The image ships a `HEALTHCHECK` that polls `GET /v1/health` on port `8620` every 15 seconds, with a 90 second start period and 3 retries, so `docker ps` reports real PD health. The entrypoint runs the start script with `-d false`, so the container process is Java itself and Docker's restart policy fires when it dies. The image also sets `STDOUT_MODE=true`, so `docker logs <container-name>` (e.g. `docker logs hg-pd0`) shows the PD log without exec-ing into the container.
 
 See [docker/README.md](https://github.com/apache/hugegraph/blob/master/docker/README.md) for the full cluster setup guide.
 
 ### 4 Configuration
 
-The main configuration file for PD is `conf/application.yml`. Here are the key configuration items:
+The main configuration file for PD is `conf/application.yml`. This is the file the distribution ships:
 
 ```yaml
 spring:
   application:
     name: hugegraph-pd
 
+management:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+logging:
+  config: 'file:./conf/log4j2.xml'
+
+license:
+  verify-path: ./conf/verify-license.json
+  license-path: ./conf/hugegraph.license
+
 grpc:
   # gRPC port for cluster mode
   port: 8686
+  # Change to the actual local IPv4 address when deploying
   host: 127.0.0.1
 
 server:
@@ -129,7 +170,7 @@ pd:
   initial-store-list: 127.0.0.1:8500
 
 raft:
-  # Cluster mode
+  # Raft address of this node
   address: 127.0.0.1:8610
   # Raft addresses of all PD nodes in the cluster
   peers-list: 127.0.0.1:8610
@@ -143,7 +184,6 @@ store:
   monitor_data_interval: 1 minute
   # Monitoring data retention time
   monitor_data_retention: 1 day
-  initial-store-count: 1
 
 partition:
   # Default number of replicas per partition
@@ -152,7 +192,173 @@ partition:
   store-max-shard-count: 12
 ```
 
-For multi-node deployment, you need to modify the port and address configurations for each node to ensure proper communication between nodes.
+`conf/application.yml.template` is a second, unused copy with placeholders (`$GRPC_PORT$`, `$RAFT_ADDRESS$` and so on) for deployment tooling that generates the file. PD always reads `conf/application.yml`, which the start script passes as `-Dspring.config.location`.
+
+#### 4.1 Configuration reference
+
+Keys not present in `conf/application.yml` fall back to the built-in default listed below. Keys with no built-in default must be present, otherwise PD fails to start.
+
+**gRPC and REST**
+
+| Key | Shipped value | Built-in default | Description |
+|-----|---------------|------------------|-------------|
+| `grpc.host` | `127.0.0.1` | none, required | Address this PD advertises for gRPC. Store and Server connect here, so set it to a reachable IPv4 address or hostname, never `127.0.0.1` or `0.0.0.0`, in a distributed deployment. |
+| `grpc.port` | `8686` | none, required | gRPC port. |
+| `server.port` | `8620` | none, required | REST API port. Also the port reported in Raft member information. |
+
+`application.yml.template` also carries `grpc.netty-server.max-inbound-message-size: 100MB`, but PD sets the gRPC server's inbound message limit to 1 GB in code, so that key has no effect.
+
+**Raft**
+
+| Key | Shipped value | Built-in default | Description |
+|-----|---------------|------------------|-------------|
+| `raft.address` | `127.0.0.1:8610` | none, required | Raft address of this node as `host:port`. Must be unique per node and must appear in `raft.peers-list`. |
+| `raft.peers-list` | `127.0.0.1:8610` | none, required | Comma separated Raft addresses of every PD node, including this one. Must be identical on all nodes. |
+| `raft.enable` | not set | `true` | When true, metadata writes go through the Raft state machine. When false, PD writes straight to its local store with no replication. |
+| `raft.ip-whitelist.enabled` | not set | `true` | When true, the Raft RPC port accepts connections only from the addresses resolved from `raft.peers-list`; other clients are dropped and logged as `Blocked connection from <ip>`. The allowlist is re-resolved when the peer list changes, but a peer that keeps its hostname and changes IP (a restarted container, for example) needs a PD restart. |
+| `raft.snapshotInterval` | not set | `300` | Seconds between Raft snapshots. |
+| `raft.rpc-timeout` | not set | `10000` | Raft RPC connect, request and install-snapshot timeout, in milliseconds. |
+
+**PD core**
+
+| Key | Shipped value | Built-in default | Description |
+|-----|---------------|------------------|-------------|
+| `pd.data-path` | `./pd_data` | none, required | Metadata directory. Holds the RocksDB store in `rocksdb/` and the Raft log, metadata and snapshots in `pd_raft/`. |
+| `pd.patrol-interval` | `1800` | `300` | Seconds between patrol runs, which check partition health across stores and rebalance partition counts. |
+| `pd.initial-store-count` | `1` | `3` | Minimum number of active Store nodes. Below this the cluster state becomes `Cluster_Not_Ready` and the cluster is treated as unavailable. Set it to the number of stores you deploy. |
+| `pd.initial-store-list` | `127.0.0.1:8500` | empty | Comma separated Store gRPC addresses (`ip:port`) that are activated automatically when they register. An entry may also carry a group id as `store_address/group_id`. |
+| `pd.cluster_id` | not set | `1` | Cluster id, used to keep separate PD clusters apart. |
+
+**Store management**
+
+| Key | Shipped value | Built-in default | Description |
+|-----|---------------|------------------|-------------|
+| `store.keepAlive-timeout` | not set | `300` | Seconds without a heartbeat after which a Store is treated as temporarily unavailable and its partition leaders move to other replicas. |
+| `store.max-down-time` | `172800` | `1800` | Seconds after which a Store is treated as permanently unavailable and its replicas are reallocated to other machines. |
+| `store.monitor_data_enabled` | `true` | `false` | Whether to persist Store monitoring samples. |
+| `store.monitor_data_interval` | `1 minute` | `1 minute` | Sampling interval, written as `<number> <unit>` with unit one of `second`, `minute`, `hour`, `day`, `month`, `year`. The number defaults to 1 when omitted. |
+| `store.monitor_data_retention` | `1 day` | `1 day` | How long monitoring samples are kept, same format as above. |
+
+**Partitions**
+
+| Key | Shipped value | Built-in default | Description |
+|-----|---------------|------------------|-------------|
+| `partition.default-shard-count` | `1` | `3` | Number of replicas per partition. Use `3` for a production cluster. |
+| `partition.store-max-shard-count` | `12` | `24` | Maximum number of partition replicas one Store holds. |
+
+The initial partition count is derived from these two values and the size of `pd.initial-store-list`:
+
+```text
+initial partitions = store count * partition.store-max-shard-count / partition.default-shard-count
+```
+
+**Discovery, license and metrics**
+
+| Key | Shipped value | Built-in default | Description |
+|-----|---------------|------------------|-------------|
+| `discovery.heartbeat-try-count` | not set | `3` | Number of missed heartbeats after which a registered client's discovery entry is deleted. |
+| `license.verify-path` | `./conf/verify-license.json` | none, required | Path to the license verification descriptor. Read by the `/v1/license` endpoints. |
+| `license.license-path` | `./conf/hugegraph.license` | none, required | Path to the license file. The distribution ships `verify-license.json` but no license file, so the license endpoints report an error until one is supplied. |
+| `auth.secret-key` | not set | built-in constant | HS256 secret used to sign the PD tokens handed back to internal clients. |
+| `management.metrics.export.prometheus.enabled` | `true` | Spring Boot default | Exposes `/actuator/prometheus`. |
+| `management.endpoints.web.exposure.include` | `"*"` | Spring Boot default | Actuator endpoints to expose. |
+| `logging.config` | `file:./conf/log4j2.xml` | none | Log4j2 configuration. Writes `logs/hugegraph-pd.log`, `logs/hugegraph-pd_raft.log` and `logs/audit-hugegraph-pd.log`. |
+
+**Thread pools**
+
+| Key | Built-in default | Description |
+|-----|------------------|-------------|
+| `thread.pool.grpc.core` | `600` | Core size of the pool that serves gRPC calls. |
+| `thread.pool.grpc.max` | `1000` | Maximum size of that pool. |
+| `thread.pool.grpc.queue` | unbounded | Queue capacity of that pool. |
+| `job.uninterruptibleThreadPool.core` | `0` | Core size of the background metadata job pool. A value of 0 or less means half the available processors. |
+| `job.uninterruptibleThreadPool.max` | `256` | Maximum size of that pool. |
+| `job.uninterruptibleThreadPool.queue` | unbounded | Queue capacity of that pool. |
+
+#### 4.2 Single-node configuration
+
+The shipped `conf/application.yml` already is a working single-node configuration. It is meant for development and testing: one PD node has no Raft quorum to lose, and `partition.default-shard-count: 1` keeps a single replica per partition.
+
+```yaml
+grpc:
+  host: 127.0.0.1
+  port: 8686
+server:
+  port: 8620
+raft:
+  address: 127.0.0.1:8610
+  peers-list: 127.0.0.1:8610
+pd:
+  data-path: ./pd_data
+  initial-store-count: 1
+  initial-store-list: 127.0.0.1:8500
+partition:
+  default-shard-count: 1
+```
+
+#### 4.3 Three-node cluster configuration
+
+For a production cluster run 3 or 5 PD nodes, an odd number so Raft always has a quorum. A 3-node cluster tolerates one node failure. `raft.peers-list` must list every node and must be byte-for-byte identical on all of them, while `grpc.host` and `raft.address` differ per node.
+
+Node 1 (`192.168.1.10`):
+
+```yaml
+grpc:
+  host: 192.168.1.10
+  port: 8686
+server:
+  port: 8620
+raft:
+  address: 192.168.1.10:8610
+  peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
+pd:
+  data-path: /data/pd
+  initial-store-count: 3
+  initial-store-list: 192.168.1.20:8500,192.168.1.21:8500,192.168.1.22:8500
+partition:
+  default-shard-count: 3
+```
+
+Node 2 (`192.168.1.11`) and node 3 (`192.168.1.12`) use the same file with `grpc.host` and `raft.address` changed to their own address:
+
+```yaml
+# node 2
+grpc:
+  host: 192.168.1.11
+raft:
+  address: 192.168.1.11:8610
+  peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
+
+# node 3
+grpc:
+  host: 192.168.1.12
+raft:
+  address: 192.168.1.12:8610
+  peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
+```
+
+To put all three PD nodes on one machine for testing, give each node its own `pd.data-path` and its own ports, for example raft `8610/8611/8612`, gRPC `8686/8687/8688` and REST `8620/8621/8622`.
+
+In Docker bridge networking the same configuration comes from environment variables and uses container hostnames instead of IP addresses:
+
+```yaml
+# pd0
+HG_PD_GRPC_HOST: pd0
+HG_PD_RAFT_ADDRESS: pd0:8610
+HG_PD_RAFT_PEERS_LIST: pd0:8610,pd1:8610,pd2:8610
+HG_PD_INITIAL_STORE_LIST: store0:8500,store1:8500,store2:8500
+HG_PD_INITIAL_STORE_COUNT: 3
+
+# pd1
+HG_PD_GRPC_HOST: pd1
+HG_PD_RAFT_ADDRESS: pd1:8610
+HG_PD_RAFT_PEERS_LIST: pd0:8610,pd1:8610,pd2:8610
+
+# pd2
+HG_PD_GRPC_HOST: pd2
+HG_PD_RAFT_ADDRESS: pd2:8610
+HG_PD_RAFT_PEERS_LIST: pd0:8610,pd1:8610,pd2:8610
+```
 
 ### 5 Start and Stop
 
@@ -164,16 +370,31 @@ In the PD installation directory, execute:
 ./bin/start-hugegraph-pd.sh
 ```
 
-The startup script supports a `-d` flag to control daemon mode:
+The script requires a JDK of at least version 11 on `PATH` or in `JAVA_HOME`, and it exits without doing anything if it finds a Java process already using this installation's `conf` directory.
+
+Supported flags:
+
+| Flag | Values | Default | Description |
+|------|--------|---------|-------------|
+| `-d` | `true`, `false` | `true` | Daemon mode. See the note below. |
+| `-g` | `zgc`, `ZGC` | not set | Garbage collector. Leave the flag off for the default G1GC. Any other value, `g1` included, aborts the start. |
+| `-j` | JVM options | empty | Extra JVM options, for example `-j "-Xmx8g -Xms8g"`. |
+| `-y` | `true`, `false` | `false` | Attach the OpenTelemetry Java agent. The agent is downloaded into `plugins/` on first use, its MD5 is verified, and traces are exported over gRPC to `http://127.0.0.1:4317`. |
+
+The `-d` flag controls daemon mode:
 
 - `-d true` (default): run as a background daemon; the script returns immediately.
-- `-d false`: run in foreground — the script `exec`s Java, so the container/supervisor process IS Java. Use this when running under Docker or a process supervisor (systemd, supervisord) so crashes are detected and the service is restarted automatically.
+- `-d false`: run in foreground. The script `exec`s Java, so the container or supervisor process IS Java. Use this when running under Docker or a process supervisor (systemd, supervisord) so crashes are detected and the service is restarted automatically.
+
+Each flag also has an environment variable equivalent: `DAEMON`, `GC_OPTION`, `USER_OPTION` and `OPEN_TELEMETRY`. Setting `JAVA_OPTIONS` replaces the computed heap settings entirely; otherwise the script sizes the heap between 512 MB and 32 GB from available memory. Setting `STDOUT_MODE=true` leaves the JVM output on stdout instead of redirecting it to `logs/hugegraph-pd-stdout.log`, which is what the Docker image does.
 
 After successful startup, you can see logs similar to the following in `logs/hugegraph-pd-stdout.log`:
 
 ```
 YYYY-mm-dd xx:xx:xx [main] [INFO] o.a.h.p.b.HugePDServer - Started HugePDServer in x.xxx seconds (JVM running for x.xxx)
 ```
+
+The process id is written to `bin/pid`.
 
 #### 5.2 Stop PD
 
@@ -183,9 +404,47 @@ In the PD installation directory, execute:
 ./bin/stop-hugegraph-pd.sh
 ```
 
-### 6 Verification
+The script reads `bin/pid`, sends the process a termination signal, waits up to 30 seconds for it to exit, and removes the pid file. If `bin/pid` is missing it reports that and exits successfully.
 
-Confirm that the PD service is running properly:
+### 6 Startup Order in a Distributed Cluster
+
+Start the components in this order:
+
+1. **All PD nodes.** They form the Raft group and elect a leader. Wait until every node answers `GET /v1/health`.
+2. **All Store nodes.** Each Store registers with PD over gRPC, and PD activates the ones listed in `pd.initial-store-list`. Wait until `GET /v1/stores` reports `"state": "Up"` for every Store.
+3. **All Server nodes.** A Server reads `pd.peers` and depends on PD reporting at least one live Store before partitions can be assigned.
+
+The Docker Compose topologies enforce exactly this. Store containers wait on PD's `/v1/health` healthcheck through `depends_on` with `condition: service_healthy`, Server containers wait the same way on the Store healthcheck, and the Server entrypoint then polls PD's `/v1/stores` until a Store reports `Up` before it starts HugeGraph.
+
+PD is also the last component to stop: shut down Server, then Store, then PD.
+
+### 7 Verification
+
+#### 7.1 REST API authentication
+
+Except for `/actuator/*`, `/v1/health` and `/v1/prom/targets/*`, every PD REST path requires an HTTP Basic `Authorization` header whose user name is one of the internal service names `hg`, `store`, `hubble` or `vermeer`. A request without the header is answered with:
+
+```json
+{"status": -1, "error": "Unauthorized!"}
+```
+
+The password is not validated yet, so any value works. The Server's own `bin/wait-storage.sh` uses `store:admin` and lets you override it with `PD_AUTH_USER` and `PD_AUTH_PASSWORD`, so the examples below use the same credentials:
+
+```bash
+curl -u store:admin http://localhost:8620/v1/stores
+```
+
+> **Warning**: This check is only meant to separate HugeGraph's own components from other traffic. Do not expose the PD REST or gRPC ports to an untrusted network. Restrict them with firewall rules or security groups, and keep `raft.ip-whitelist.enabled` on so the Raft port only accepts the configured peers.
+
+#### 7.2 Health check
+
+`GET /v1/health` needs no credentials and is what the Docker healthcheck uses. It answers `200` with an empty body:
+
+```bash
+curl -i http://localhost:8620/v1/health
+```
+
+The Spring Boot actuator endpoint also works and is more readable:
 
 ```bash
 curl http://localhost:8620/actuator/health
@@ -193,10 +452,24 @@ curl http://localhost:8620/actuator/health
 
 If it returns `{"status":"UP"}`, it indicates that the PD service has been successfully started.
 
+#### 7.3 Cluster and member status
+
+Check the PD members and which node is the Raft leader:
+
+```bash
+curl -u store:admin http://localhost:8620/v1/members
+```
+
+The response carries `pdList`, the elected `pdLeader`, `numOfService`, `numOfNormalService` and a `stateCountMap`. In a healthy 3-node PD cluster `numOfService` and `numOfNormalService` are both `3` and exactly one member has `role: "Leader"`.
+
+`GET /v1/cluster` returns the same member list together with the Store list, graph list and overall cluster state, and `GET /` returns a short summary (leader address, cluster state, member count, store count, graph count, partition count).
+
+#### 7.4 Store status
+
 You can also verify Store node status through the PD API:
 
 ```bash
-curl http://localhost:8620/v1/stores
+curl -u store:admin http://localhost:8620/v1/stores
 ```
 
 If the response shows `state` as `Up`, the corresponding Store node is running normally. The example below shows a single Store node. In a healthy 3-node deployment, the `storeId` list should contain three IDs, and `stateCountMap.Up`, `numOfService`, and `numOfNormalService` should all be `3`.
@@ -212,7 +485,7 @@ If the response shows `state` as `Up`, the corresponding Store node is running n
         "raftAddress": "127.0.0.1:8510",
         "version": "",
         "state": "Up",
-        "deployPath": "/Users/{your_user_name}/hugegraph/apache-hugegraph-incubating-1.5.0/apache-hugegraph-store-incubating-1.5.0/lib/hg-store-node-1.5.0.jar",
+        "deployPath": "/Users/{your_user_name}/hugegraph/apache-hugegraph-incubating-1.7.0/apache-hugegraph-store-incubating-1.7.0/lib/hg-store-node-1.7.0.jar",
         "dataPath": "./storage",
         "startTimeStamp": 1754027127969,
         "registedTimeStamp": 1754027127969,
@@ -238,3 +511,61 @@ If the response shows `state` as `Up`, the corresponding Store node is running n
   "status": 0
 }
 ```
+
+#### 7.5 Other REST endpoints
+
+All paths below are relative to `http://<pd-host>:8620` and need the Basic header from section 7.1 unless noted.
+
+| Method and path | Description |
+|-----------------|-------------|
+| `GET /` | Brief cluster statistics: leader, state, member count, store count, graph count, partition count |
+| `GET /v1/health` | Health check, no authentication required |
+| `GET /v1/cluster` | Full cluster statistics: PD members, stores, graphs, partitions |
+| `GET /v1/members` | PD member list with roles and the elected leader |
+| `POST /v1/members/change` | Change the Raft peer list, body `{"peerList": "..."}` |
+| `GET /v1/stores` | Registered Store nodes with state and per-store statistics |
+| `GET /v1/store/{storeId}` | One Store node |
+| `POST /v1/store/{storeId}` | Update a Store's state, body `{"storeState": "..."}` |
+| `DELETE /v1/store/{storeId}` | Remove a Store from the cluster |
+| `POST /v1/store/log` | Store state change log, body `{"startTime": "...", "endTime": "..."}` |
+| `GET /v1/storesAndStats` | Raw Store metadata, for debugging |
+| `GET /v1/store_monitor/{storeId}` | Store monitoring samples as text |
+| `GET /v1/store_monitor/json/{storeId}` | Store monitoring samples as JSON |
+| `GET /v1/shards` | Every shard of every partition, with store id, role, state and progress |
+| `GET /v1/shardGroups` | Shard groups |
+| `GET /v1/shardGroupsCache` | Shard groups from PD's in-memory cache |
+| `GET /v1/shardLeaders` | Partition leaders grouped by Store raft address |
+| `GET /v1/balanceLeaders` | Rebalance partition leaders across Stores |
+| `GET /v1/partitions` | Partition list with state and statistics |
+| `GET /v1/highLevelPartitions` | Partitions with per-graph key counts and data sizes |
+| `GET /v1/partitionsAndStats` | Raw partition metadata, for debugging |
+| `POST /v1/partitions/log` | Partition change log, body `{"startTime": "...", "endTime": "..."}` |
+| `GET /v1/resetPartitionState` | Reset the state of every partition |
+| `GET /v1/graphs` | Graph list |
+| `GET /v1/graph/**` | One graph by name |
+| `POST /v1/graph/**` | Update a graph's partition count, body `{"partitionCount": N}` |
+| `GET /v1/graph/partitionSizeRange` | Minimum and maximum partition count the cluster accepts |
+| `GET /v1/graph-spaces` | Graph space list |
+| `GET /v1/graph-spaces/**` | One graph space |
+| `POST /v1/graph-spaces/**` | Update a graph space |
+| `POST /v1/registry` | Register a service instance for discovery |
+| `POST /v1/registryInfo` | Query registered instances |
+| `GET /v1/allInfo` | All registered instances |
+| `GET /v1/license` | License context |
+| `GET /v1/license/machineInfo` | IP and MAC addresses seen by the license check |
+| `GET /v1/task/patrolStores` | Run the store patrol task now |
+| `GET /v1/task/patrolPartitions` | Run the partition patrol task now |
+| `GET /v1/task/balancePartitions` | Rebalance partitions across Stores |
+| `GET /v1/task/splitPartitions` | Run automatic partition splitting now |
+| `GET /v1/task/balanceLeaders` | Rebalance partition leaders |
+| `GET /v1/task/compact` | Instruct Store nodes to compact the RocksDB files of their partitions |
+| `GET /v1/prom/targets/{appName}` | Prometheus service discovery targets, no authentication required |
+| `GET /v1/prom/targets-all` | Prometheus targets for all app types |
+| `GET /v1/prom/sd_config` | Prometheus HTTP service discovery config |
+| `GET /actuator/health` | Spring Boot health, no authentication required |
+| `GET /actuator/metrics` | Spring Boot metrics, no authentication required |
+| `GET /actuator/prometheus` | Prometheus scrape endpoint, no authentication required |
+
+The two `log` endpoints take a time range as `{"startTime": "...", "endTime": "..."}`; `yyyy-MM-dd HH:mm:ss` and `yyyy-MM-dd` are among the accepted formats.
+
+PD registers its own meters under the `hg` prefix, so `/actuator/prometheus` exposes `hg_up`, `hg_graphs`, `hg_stores` and `hg_terms` alongside the standard JVM metrics, plus per-graph partition and size meters once graphs exist.


### PR DESCRIPTION
Syncs the HugeGraph-PD quickstart page (en and cn) with `apache/hugegraph` master. Every change below traces to a file on master; no other page is touched.

| page | what was wrong | what changed | source (file:line on master) |
|------|----------------|--------------|------------------------------|
| quickstart/hugegraph/hugegraph-pd.md | The `application.yml` sample put `initial-store-count: 1` under `store:`. No such key exists; PD only binds `pd.initial-store-count`. | Removed it, and the sample now mirrors the shipped file exactly, including the `management`, `logging` and `license` blocks it was missing. | hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml:22-79; hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java:52 |
| quickstart/hugegraph/hugegraph-pd.md | The verification section used `curl http://localhost:8620/v1/stores` with no credentials. PD registers a REST interceptor on `/**`, so that request answers `{"status":-1,"error":"Unauthorized!"}`. | Added section 7.1 on REST authentication (HTTP Basic, user name must be one of `hg`, `store`, `hubble`, `vermeer`, password not validated yet), listed the exempt paths, and changed every example to `curl -u store:admin`, the credentials the Server's own wait script uses. | hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/interceptor/AuthenticationConfigurer.java:33-36; .../rest/interceptor/RestAuthentication.java:48-60; .../service/interceptor/Authentication.java:62-87; hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh:42 |
| quickstart/hugegraph/hugegraph-pd.md | `/actuator/health` was the only health check shown. `/v1/health` is the endpoint the image healthcheck and the release test script actually use, and it is the one that needs no credentials. | Documented `GET /v1/health` first, kept `/actuator/health` as the more readable alternative. | hugegraph-pd/Dockerfile:68-69; docker/docker-compose-hstore.yml:47; hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph-pd.sh:103-104 |
| quickstart/hugegraph/hugegraph-pd.md | The config section listed 12 keys with no defaults and no note of which are required. Most of `application.yml` was undocumented. | Added section 4.1, a full reference for every key PD binds, split into gRPC/REST, Raft, PD core, Store management, Partitions, Discovery/license/metrics and thread pools, with the shipped value, the built-in default and the meaning of each. | hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java:44-311; hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml:22-79 |
| quickstart/hugegraph/hugegraph-pd.md | `raft.enable`, `raft.ip-whitelist.enabled`, `raft.snapshotInterval`, `raft.rpc-timeout`, `store.keepAlive-timeout`, `pd.cluster_id`, `discovery.heartbeat-try-count`, `auth.secret-key` and the thread-pool keys were absent. | All added, with defaults from the binding class. The Raft IP allowlist entry explains that it drops non-peer connections and that a peer keeping its hostname but changing IP needs a restart. | PDConfig.java:141-153, 175, 44, 291, 72, 129-134, 307-311; hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/raft/auth/IpAuthHandler.java:62-93; .../raft/RaftEngine.java:154-182 |
| quickstart/hugegraph/hugegraph-pd.md | The page had no cluster example at all, only "For multi-node deployment, you need to modify the port and address configurations for each node". | Added 4.2 single-node and 4.3 three-node cluster configurations, with the per-node files, the identical `raft.peers-list` rule, the all-on-one-host port layout, and the Docker bridge equivalent. | hugegraph-pd/hg-pd-core/.../PDConfig.java:145-150; docker/docker-compose-3pd-3store-3server.yml:96-148 |
| quickstart/hugegraph/hugegraph-pd.md | Only `-d` was documented for `start-hugegraph-pd.sh`. | Added `-g`, `-j` and `-y` with their accepted values, the `DAEMON`/`GC_OPTION`/`USER_OPTION`/`OPEN_TELEMETRY`/`JAVA_OPTIONS`/`STDOUT_MODE` environment equivalents, the 512 MB to 32 GB heap sizing, the already-running guard, and what `stop-hugegraph-pd.sh` does with `bin/pid`. Noted that `-g g1` aborts the start, only `zgc`/`ZGC` or no flag are accepted. | hugegraph-pd/hg-pd-dist/src/assembly/static/bin/start-hugegraph-pd.sh:20-42, 70-72, 107-123, 166-199; .../bin/stop-hugegraph-pd.sh:35-48; .../bin/util.sh:180-198, 374-396 |
| quickstart/hugegraph/hugegraph-pd.md | Nothing said where PD sits in the cluster startup sequence. | Added section 6 with the PD, Store, Server order, what to wait for at each step, how Compose enforces it, and the reverse shutdown order. | docker/docker-compose-hstore.yml:46-60, 84-86; docker/docker-compose-3pd-3store-3server.yml:39-44, 51-54, 79-82; hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh:189; hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh:100-118 |
| quickstart/hugegraph/hugegraph-pd.md | No list of PD REST endpoints, so there was no way to tell which paths exist. | Added section 7.5 listing every mapping in `hg-pd-service`, with the request bodies for the POST endpoints and a note on which paths skip authentication. Also added 7.3 for `/v1/members`, `/v1/cluster` and `/`. | hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/ (IndexAPI, MemberAPI, StoreAPI, ShardAPI, PartitionAPI, GraphAPI, GraphSpaceAPI, RegistryAPI, TaskAPI, SDConfigAPI) |
| quickstart/hugegraph/hugegraph-pd.md | The Docker section did not mention the image healthcheck, the `-d false` entrypoint, or what happens when a required variable is missing. | Added the healthcheck parameters, the `SPRING_APPLICATION_JSON` mechanism, the required-variable check, `JAVA_OPTS` passthrough, and the `HG_PD_*` to `application.yml` key mapping in the variable table. | hugegraph-pd/Dockerfile:42-72; hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh:44-85 |
| quickstart/hugegraph/hugegraph-pd.md | The build step named only two output paths and no way to build PD alone. | Listed all three outputs, noted the PD-only tarball is produced on Linux build hosts only, added the layout of the unpacked distribution and the `-pl hugegraph-pd/hg-pd-dist -am` command. | hugegraph-pd/pom.xml:47; hugegraph-pd/hg-pd-dist/pom.xml:33, 40-46, 61-67, 95-125; install-dist/pom.xml:32, 47-62; hugegraph-pd/hg-pd-dist/src/assembly/descriptor/server-assembly.xml:26-55 |
| quickstart/hugegraph/hugegraph-pd.md | The overview did not say what PD stores or which ports it opens, and the sample store response referenced 1.5.0 paths while the download step uses 1.7.0. | Added the storage layout, the port table, and updated the sample `deployPath` to 1.7.0. | hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/store/HgKVStoreImpl.java:70; .../raft/RaftEngine.java:96, 113-117; PDConfig.java:145, 157, 162 |
| quickstart/hugegraph/hugegraph-pd.md (cn) | The cn page was missing the sample `/v1/stores` response that the en page has. | Added it, and mirrored every change above into the cn page. | n/a |

Also removed the em dashes that were already in both files, so the pages use plain ASCII punctuation.
