### PR TITLE
doc(server): sync backend-rocksdb with master

### DIFF
--- a/content/cn/docs/config/config-backend-rocksdb.md
+++ b/content/cn/docs/config/config-backend-rocksdb.md
@@ -1,0 +1,273 @@
+---
+title: "配置 RocksDB 后端"
+linkTitle: "配置 RocksDB 后端"
+weight: 5
+---
+
+### 概述
+
+RocksDB 是一个嵌入式的 LSM-tree 键值存储。使用 `rocksdb` 后端时，HugeGraph-Server 把全部图数据保存在
+服务进程内部的 RocksDB 实例中，不需要额外部署存储服务。发布包中的 `conf/graphs/hugegraph.properties`
+默认使用的就是这个后端。
+
+从 1.7.0 版本开始，服务端只接受 `memory`、`rocksdb`、`hbase` 和 `hstore` 作为后端。`rocksdb` 后端把
+数据写在单台服务器的本地磁盘上，不支持共享存储，因此多个服务无法基于同一个数据目录提供同一个图。
+分布式部署请使用 `hstore` 后端，配合 PD 与 Store。
+
+RocksDB 的 JNI 依赖在 `hugegraph-rocksdb/pom.xml` 中固定为 `8.10.2` 版本，因此磁盘格式与各配置项的
+语义都以 RocksDB 8.10 为准。
+
+该后端上报的驱动版本是 `1.11`，在初始化图时会写入 system store 的 meta 表中。
+
+### 选择后端
+
+在图配置文件（`conf/graphs/<graph>.properties`）中设置后端与序列化器：
+
+```properties
+gremlin.graph=org.apache.hugegraph.HugeFactory
+
+backend=rocksdb
+serializer=binary
+
+store=hugegraph
+
+# rocksdb backend config
+#rocksdb.data_path=/path/to/disk
+#rocksdb.wal_path=/path/to/disk
+```
+
+- `backend=rocksdb` 选择 RocksDB 存储实现。
+- `serializer=binary` 是发布包模板为该后端使用的序列化器。内置的序列化器为 `binary`、`binaryscatter`
+  和 `text`。
+- `store` 是该图在后端中的库名，同时也是存储实现拿到的图名的一部分。
+
+首次启动前执行一次 `bin/init-store.sh` 创建各个 store，然后再启动服务。`bin/init-store.sh` 与
+`bin/hugegraph-server.sh` 都会加载 RocksDB 库，数据目录在执行这些脚本的机器上创建。
+
+发布包会为打包时 `backend.properties` 中列出的每个后端注册配置项空间和存储实现，该文件的取值来自
+`hugegraph.backends` 构建属性。默认构建会注册 `rocksdb, hbase, hstore`；使用 `-Drocksdb-only` 构建会
+激活 `rocksdb-only` profile，产出的发布包只注册 `rocksdb`。未注册的后端在启动时会报
+`Not exists BackendStoreProvider`。
+
+注册过程还会额外注册一个名字 `rocksdbsst`，它对应的实现写出 SST 文件而不是打开一个可用的数据库。
+该名字不在允许的后端列表中，因此 `backend=rocksdbsst` 会被拒绝并报 `backend is illegal: rocksdbsst`。
+如果要把 SST 文件导入普通的 `rocksdb` 图，请使用下面介绍的 `rocksdb.sst_path`。
+
+### 数据目录结构
+
+有两个目录需要关注：`rocksdb.data_path`（默认 `rocksdb-data/data`）和 `rocksdb.wal_path`
+（默认 `rocksdb-data/wal`）。相对路径基于服务的工作目录解析，也就是安装目录。
+
+每个图会打开三个 store：`m` 存放 schema，`g` 存放图数据，`s` 是 system store。store 名会拼接到上面
+两个路径之后，因此一个默认的单图安装目录如下：
+
+```
+rocksdb-data/
+  data/
+    m/    # schema store：属性键、顶点/边/索引标签、计数器
+    g/    # graph store：顶点、边、索引表、olap 表
+    s/    # system store：任务、服务信息、后端 meta（驱动版本）
+  wal/
+    m/
+    g/
+    s/
+```
+
+后端的每张表在所属 store 中对应一个 RocksDB 列族，名字形如 `<database>+<table>`，其中 database 由图名
+推导得到。已有数据目录中的列族总是会被重新打开，因此旧版本创建的表仍然可读。
+
+还需要注意：
+
+- 两个图不能共用同一个数据路径。通过 API 基于已有配置克隆创建图时，存储实现会在
+  `rocksdb.data_path` 和 `rocksdb.wal_path` 后面追加 `_<newGraph>`。删除这样的图会同时删除这两个目录。
+- 快照创建在数据目录旁边：数据路径的最后两段会加上前缀重写，因此在默认路径下 graph store 的快照位于
+  `rocksdb-data/<prefix>_data/g`。恢复快照时会先关闭实例，删除数据目录，再把快照移动到原位置。
+- 设置了 `rocksdb.data_disks` 时，其中列出的表会在指定路径下作为独立的 RocksDB 实例打开，而不再放在
+  `rocksdb.data_path` 下。服务最多并发打开 8 个实例，打开最多等待 600 秒，会话关闭最多等待 30 秒。
+
+### 路径与日志配置项
+
+| config option        | default value       | description                                                                                                                                                                                                                                                                                                                                       |
+|----------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.data_path    | `rocksdb-data/data` | RocksDB 数据存储路径，不允许为空。                                                                                                                                                                                                                                                                                                                |
+| rocksdb.data_disks   | `[]`                | 为部分表指定独立磁盘，每个元素格式为 `STORE/TABLE: /path/disk`。允许的键为 [g/vertex, g/edge_out, g/edge_in, g/vertex_label_index, g/edge_label_index, g/range_int_index, g/range_float_index, g/range_long_index, g/range_double_index, g/secondary_index, g/search_index, g/shard_index, g/unique_index, g/olap]。磁盘路径不能与 `rocksdb.data_path` 相同。 |
+| rocksdb.wal_path     | `rocksdb-data/wal`  | RocksDB WAL 存储路径，不允许为空。                                                                                                                                                                                                                                                                                                                |
+| rocksdb.sst_path     | （空）              | 待导入 RocksDB 的 SST 文件所在路径，为空表示不导入。                                                                                                                                                                                                                                                                                              |
+| rocksdb.log_level    | `INFO`              | RocksDB 的日志级别，可选值：DEBUG、INFO、WARN、ERROR、FATAL、HEADER。                                                                                                                                                                                                                                                                             |
+
+### 压缩与合并配置项
+
+| config option                  | default value                                          | description                                                                                                                            |
+|--------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.num_levels             | `7`                                                    | 数据库的层数，取值范围 1 到 2^31-1。                                                                                                   |
+| rocksdb.compaction_style       | `LEVEL`                                                | RocksDB 的 compaction 策略：LEVEL/UNIVERSAL/FIFO。                                                                                     |
+| rocksdb.optimize_mode          | `true`                                                 | 针对高负载和大数据量做优化，具体行为见下文的配置项生效方式一节。                                                                         |
+| rocksdb.bulkload_mode          | `false`                                                | 切换到批量导入数据的模式。                                                                                                              |
+| rocksdb.compression_per_level  | `[none, none, snappy, snappy, snappy, snappy, snappy]` | 各层使用的压缩算法，可选值为 none/snappy/z/bzip2/lz4/lz4hc/xpress/zstd。列表必须为空，或者元素个数正好等于 `rocksdb.num_levels`。         |
+| rocksdb.bottommost_compression | `none`                                                 | 最底层使用的压缩算法，可选值为 none/snappy/z/bzip2/lz4/lz4hc/xpress/zstd。                                                               |
+| rocksdb.compression            | `snappy`                                               | 压缩数据块使用的压缩算法，可选值为 none/snappy/z/bzip2/lz4/lz4hc/xpress/zstd。                                                           |
+
+### 数据库级配置项
+
+| config option                          | default value        | description                                                                                                     |
+|----------------------------------------|----------------------|-----------------------------------------------------------------------------------------------------------------|
+| rocksdb.max_background_jobs            | `8`                  | 后台任务（包括 flush 和 compaction）的最大并发数，取值范围 1 到 2^31-1。                                          |
+| rocksdb.max_subcompactions             | `4`                  | 单个 compaction 任务使用的最大线程数，取值范围 1 到 2^31-1。                                                     |
+| rocksdb.delayed_write_rate             | `16777216`（16 MB/s）| 当 compaction 落后需要降速时，用户写请求的限速值，单位字节每秒。                                                  |
+| rocksdb.max_open_files                 | `-1`                 | RocksDB 可缓存的最大打开文件数，-1 表示不限制。                                                                  |
+| rocksdb.max_manifest_file_size         | `104857600`（100 MB）| manifest 文件的最大字节数。                                                                                      |
+| rocksdb.skip_stats_update_on_db_open   | `false`              | 打开数据库时是否跳过统计信息更新，设为 true 表示不更新统计信息。                                                  |
+| rocksdb.skip_check_sst_size_on_db_open | `false`              | 打开数据库时是否跳过检查所有 sst 文件的大小。                                                                    |
+| rocksdb.max_file_opening_threads       | `16`                 | 打开文件使用的最大线程数，取值范围 1 到 2^31-1。                                                                 |
+| rocksdb.max_total_wal_size             | `0`                  | WAL 文件的总大小上限，单位字节。超过后会强制 flush 相关的列族，0 表示不限制。                                     |
+| rocksdb.bytes_per_sync                 | `0`                  | 允许操作系统在后台异步地增量同步正在写入的 SST 文件，每写入这么多字节发起一次请求，0 表示关闭。                    |
+| rocksdb.wal_bytes_per_sync             | `0`                  | 同上，作用于 WAL 文件，0 表示关闭。                                                                              |
+| rocksdb.strict_bytes_per_sync          | `false`              | 为 true 时保证任意时刻提交回写的 SST/WAL 数据不超过 bytes_per_sync/wal_bytes_per_sync 字节，可用于处理写入速度超过 I/O 速度的场景。 |
+| rocksdb.db_write_buffer_size           | `0`                  | 所有列族 write buffer 的总大小上限，单位字节，0 表示不限制。                                                     |
+| rocksdb.log_readahead_size             | `0`                  | 读取日志时预取的字节数，0 表示关闭预取。                                                                         |
+| rocksdb.compaction_readahead_size      | `0`                  | compaction 时批量读取的字节数。如果 RocksDB 跑在机械盘上，建议至少设为 2MB，0 表示关闭预取。                       |
+| rocksdb.row_cache_capacity             | `0`                  | 表级行缓存的全局容量，单位字节，0 表示关闭 row_cache。                                                            |
+| rocksdb.delete_obsolete_files_period   | `21600`（6 小时）    | 删除废弃文件的周期，单位秒，0 表示每次都做完整清理。该值传给 RocksDB 前会换算成微秒。                              |
+
+### Memtable 配置项
+
+| config option                               | default value        | description                                                                                                                     |
+|---------------------------------------------|----------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.write_buffer_size                   | `134217728`（128 MB）| 在内存中累积的数据量，单位字节，最小 1 MB。该值针对单个列族生效。                                                                 |
+| rocksdb.max_write_buffer_number             | `6`                  | 内存中累积的 write buffer 的最大个数，取值范围 1 到 2^31-1。                                                                     |
+| rocksdb.min_write_buffer_number_to_merge    | `2`                  | 会被合并到一起的 write buffer 的最小个数，取值范围 1 到 2^31-1。                                                                 |
+| rocksdb.max_write_buffer_number_to_maintain | `0`                  | 使用事务时，为冲突检查在内存中保留的 write buffer 总数上限。                                                                      |
+| rocksdb.memtable_bloom_size_ratio           | `0.0`                | 设置了 prefix-extractor 且该值不为 0，或者 memtable_whole_key_filtering 为 true 时，为 memtable 创建大小为 write_buffer_size * memtable_bloom_size_ratio 的布隆过滤器。大于 0.25 的取值会被收敛为 0.25，取值范围 0.0 到 1.0。 |
+| rocksdb.memtable_whole_key_filtering        | `false`              | 在 memtable 中启用全键布隆过滤器，可以降低点查的 CPU 开销。只有 memtable_bloom_size_ratio > 0 时才生效。                          |
+| rocksdb.memtable_huge_page_size             | `0`                  | memtable 中布隆过滤器使用的 huge page TLB 的页大小，小于等于 0 时不从 huge page TLB 分配，改用 malloc。                            |
+| rocksdb.inplace_update_support              | `false`              | 当写入的键已存在于当前 memtable 且新值更小时，允许线程安全的原地更新。                                                             |
+
+### 层级大小与写入限流配置项
+
+| config option                                | default value           | description                                                                                                                                                                                                        |
+|----------------------------------------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.level_compaction_dynamic_level_bytes | `false`                 | 是否启用 level_compaction_dynamic_level_bytes。启用后 max_bytes_for_level_multiplier 的优先级高于 max_bytes_for_level_base，基准层的大小是动态的，LSM tree 更可预测，有助于限制最差情况下的空间放大。对已有数据库开关该特性可能造成异常的 LSM tree 结构，因此不推荐改动。 |
+| rocksdb.max_bytes_for_level_base             | `536870912`（512 MB）   | level-1 文件总大小的上限，单位字节，最小 1 MB。                                                                                                                                                                    |
+| rocksdb.max_bytes_for_level_multiplier       | `10.0`                  | 对所有层 L，第 L+1 层文件总大小与第 L 层文件总大小的比值，最小 1.0。                                                                                                                                               |
+| rocksdb.target_file_size_base                | `67108864`（64 MB）     | compaction 的目标文件大小，单位字节，最小 1 MB。                                                                                                                                                                   |
+| rocksdb.target_file_size_multiplier          | `1`                     | 第 L 层文件与第 L+1 层文件的大小比值。                                                                                                                                                                             |
+| rocksdb.level0_file_num_compaction_trigger   | `2`                     | 触发 level-0 compaction 的文件数。                                                                                                                                                                                 |
+| rocksdb.level0_slowdown_writes_trigger       | `20`                    | 触发写入降速的 level-0 文件数软上限。                                                                                                                                                                              |
+| rocksdb.level0_stop_writes_trigger           | `36`                    | 触发停写的 level-0 文件数硬上限。                                                                                                                                                                                   |
+| rocksdb.soft_pending_compaction_bytes_limit  | `68719476736`（64 GB）  | 待 compaction 数据量的软上限，单位字节，最小 1 GB。                                                                                                                                                                |
+| rocksdb.hard_pending_compaction_bytes_limit  | `274877906944`（256 GB）| 待 compaction 数据量的硬上限，单位字节，最小 1 GB。                                                                                                                                                                |
+
+### 文件 I/O 配置项
+
+| config option                                  | default value | description                                                                                          |
+|------------------------------------------------|---------------|------------------------------------------------------------------------------------------------------|
+| rocksdb.allow_mmap_writes                      | `false`       | 允许操作系统以 mmap 方式写文件。                                                                     |
+| rocksdb.allow_mmap_reads                       | `false`       | 允许操作系统以 mmap 方式读取 sst 文件。                                                              |
+| rocksdb.use_direct_reads                       | `false`       | 读取 sst 文件时使用直接 I/O。                                                                        |
+| rocksdb.use_direct_io_for_flush_and_compaction | `false`       | flush 和 compaction 时使用直接读写。                                                                 |
+| rocksdb.use_fsync                              | `false`       | 为 true 时每次持久化都会执行 fsync。                                                                 |
+| rocksdb.atomic_flush                           | `false`       | 为 true 时多个列族的 flush 结果会原子地提交到 MANIFEST。WAL 一直开启的情况下不必设置该项。             |
+
+### SST 表格式与块缓存配置项
+
+| config option                            | default value            | description                                                                                                                          |
+|------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.format_version                   | `5`                      | BlockBasedTable 的格式版本，可选值为 0~5。                                                                                            |
+| rocksdb.index_type                       | `kBinarySearch`          | sst 文件中数据块之间查找使用的索引类型，可选值为 [kBinarySearch, kHashSearch, kTwoLevelIndexSearch, kBinarySearchWithFirstKey]。        |
+| rocksdb.data_block_index_type            | `kDataBlockBinarySearch` | sst 文件数据块内点查使用的查找类型，可选值为 [kDataBlockBinarySearch, kDataBlockBinaryAndHash]。                                        |
+| rocksdb.data_block_hash_table_util_ratio | `0.75`                   | 哈希表 entries/buckets 的使用率，仅在 data_block_index_type=kDataBlockBinaryAndHash 时有效，取值范围 0.0 到 1.0。                       |
+| rocksdb.block_size                       | `4096`（4 KB）           | 每个块中打包的用户数据的近似大小，注意对应的是未压缩的数据。                                                                            |
+| rocksdb.block_size_deviation             | `10`                     | 用于结束一个块的空闲空间百分比，取值范围 0 到 100。                                                                                    |
+| rocksdb.block_restart_interval           | `16`                     | 块内增量编码的 restart 间隔。                                                                                                          |
+| rocksdb.block_cache_capacity             | `8388608`（8 MB）        | RocksDB 使用的块缓存大小，单位字节，0 表示不使用块缓存。每个列族都会创建一个该大小的独立缓存。                                          |
+
+### 布隆过滤器配置项
+
+只有 `rocksdb.bloom_filter_bits_per_key` 大于等于 0 时，本组的配置项才会被读取。默认值 -1 表示不启用
+布隆过滤器，此时本表中其他配置项都不生效，包括索引和过滤块的缓存相关项。
+
+| config option                                   | default value | description                                                                                                                                     |
+|-------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.bloom_filter_bits_per_key               | `-1`          | 布隆过滤器中每个键占用的位数，10 是一个不错的取值，对应约 1% 的误判率。大于 0 表示启用布隆过滤器，-1 表示不启用（0~0.5 向下取整为不启用）。        |
+| rocksdb.bloom_filter_block_based_mode           | `false`       | 启用布隆过滤器时，设为 true 表示使用 block based filter 而不是 full filter。                                                                      |
+| rocksdb.bloom_filter_whole_key_filtering        | `true`        | 启用布隆过滤器时，设为 true 表示把完整的键放入布隆过滤器，否则在设置了 prefix-extractor 时放入键的前缀。                                          |
+| rocksdb.cache_index_and_filter_blocks           | `true`        | 设为 true 表示把索引块和过滤块放入块缓存。                                                                                                        |
+| rocksdb.pin_l0_filter_and_index_blocks_in_cache | `true`        | 设为 true 表示把 L0 的索引块和过滤块固定在块缓存中。                                                                                              |
+| rocksdb.optimize_filters_for_hits               | `true`        | 启用布隆过滤器时，该开关允许不为最后一层存储过滤器，设为 true 表示主要针对命中的场景优化过滤器，而不是同时优化未命中的场景。该项在过滤器关闭时也会生效。 |
+| rocksdb.partition_filters_and_indexes           | `false`       | 启用布隆过滤器时，设为 true 表示每个 sst 文件使用分区的 full filter 和索引。该项与 block based filter 不兼容。开启后索引类型会被强制为 kTwoLevelIndexSearch，元数据块大小取 `rocksdb.block_size`。 |
+| rocksdb.pin_top_level_index_and_filter          | `true`        | 当 partition_filters_and_indexes 为 true 时，设为 true 表示把分区过滤块和索引块的顶层索引固定在块缓存中。                                          |
+| rocksdb.prefix_extractor_n_bytes                | `0`           | prefix-extractor 取键的前 N 个字节作为前缀，键长度小于 N 时使用完整键，0 表示不设置 prefix-extractor。                                             |
+
+### 配置项的生效方式
+
+服务为每个 store 和每个列族构建一次 RocksDB 的选项对象，因此上面任何配置项的修改都在下次启动服务时
+生效。
+
+- `rocksdb.optimize_mode=true` 会在应用上表中的取值之前先套用一组预设：数据库层面把并行度提高到可用
+  处理器数的一半（至少 1），允许 memtable 并发写入，并开启写线程自适应让出；列族层面调用 RocksDB 的
+  level-style 和 universal-style compaction 预设。显式配置项在之后应用，因此配置文件中写明的取值会覆盖
+  预设。
+- `rocksdb.bulkload_mode=true` 会关闭自动 compaction，把三个 level-0 触发阈值提高到 int 最大值，把两个
+  待 compaction 上限提高到 long 最大值。导入结束后要关闭它并重启，否则 compaction 不会运行。
+- `rocksdb.block_cache_capacity=0` 表示彻底关闭块缓存，而不是不限制大小。
+- `rocksdb.prefix_extractor_n_bytes` 大于 0 时会安装一个该长度的 capped prefix extractor。
+- 所有列族都使用 `uint64add` merge 操作符，计数器表依赖它。
+- 数据库不存在时会自动创建，`avoid_unnecessary_blocking_io` 和 `write_dbid_to_manifest` 始终开启。
+
+### 内存说明
+
+RocksDB 的缓存和 write buffer 都是本地内存分配，不属于 `bin/hugegraph-server.sh` 中设置的 JVM 堆。
+`GET /metrics/backend` 接口会返回存储的使用量：内存数值是所有已打开列族的块缓存用量、固定在块缓存中的
+用量、预估的 table reader 内存（索引块和过滤块）以及全部 memtable 大小之和，取自 RocksDB 的属性。
+
+有两个配置项的实际占用会随列族数量成倍增长：
+
+- `rocksdb.block_cache_capacity` 为每个列族创建一个缓存实例，因此一台服务的块缓存总量大致等于该值乘以
+  所有图的 `m`、`g`、`s` 三个 store 中已打开表的数量，再加上 `rocksdb.data_disks` 额外打开的实例。
+- `rocksdb.write_buffer_size` 乘以 `rocksdb.max_write_buffer_number` 限定的是单个列族的 memtable 内存。
+  `rocksdb.db_write_buffer_size` 限制一个 store 内所有列族的总量，默认值 0 表示没有这个限制。
+
+`rocksdb.row_cache_capacity` 不同：它是每个 store 一个缓存，0 表示关闭。
+
+### 导入 SST 文件
+
+设置 `rocksdb.sst_path` 即开启导入。打开 store 时以及每次创建表时，服务会遍历
+`<sst_path>/<column family>/` 目录，收集其中所有非空的 `*.sst` 文件，导入到对应的列族。导入采用移动
+文件的方式而不是复制，因此源目录会被导入过程消耗掉。
+
+### raft 模式
+
+RocksDB 后端仍然可以运行在 raft 状态机之后：`raft.mode=true` 时，本地后端的存储实现会被 raft 实现包装。
+包装层会拒绝共享存储的后端，因此 `rocksdb` 可用而 `hbase` 不可用。raft 模式下 RocksDB 会话写入时关闭
+WAL 且不做 sync，因为状态机可以通过快照加 raft 日志恢复，而该后端支持快照。
+
+使用时需要注意：
+
+- `bin/init-store.sh` 在初始化后端时会强制把 `raft.mode` 置为 false，因此初始化过程不会走 raft。
+- 发布包中的 `conf/graphs/hugegraph.properties` 已把 raft 相关配置标记为废弃。1.7.0 及之后版本的分布式
+  部署改用 `hstore` 后端，配合 PD 与 Store。
+- raft 成员管理接口位于 `graphspaces/{graphspace}/graphs/{graph}/raft/` 之下，包括 `list_peers`、
+  `get_leader`、`set_leader`、`transfer_leader`、`add_peer` 和 `remove_peer`。`bin/raft-tools.sh` 封装了
+  同样的操作，但它拼接的 URL 中仍然没有 graphspace 段，在 1.7.0 的服务上需要调整路径才能使用。
+- 其余 `raft.*` 配置项见 [Server 配置选项](config-option)。
+
+### 后端能力
+
+该后端的特性开关决定了哪些操作可以下推给存储：
+
+- 支持按键前缀扫描、按键范围扫描、分页查询、范围条件和 order-by。
+- RocksDB 内部没有索引，因此按名字查询 schema、按标签查询以及按标签删除边由服务端完成，而不是由存储
+  完成。
+- 通过 RocksDB 的 write batch 支持事务。
+- 支持快照，raft 模式和备份依赖该能力。
+- 不支持共享存储，一个数据目录属于一台服务。
+- 支持 olap 属性，对应的表会作为额外的列族创建。
+- 存储本身不会让数据过期，因此服务端在读取时过滤掉 TTL 已到期的元素。
+- 存储层不支持 `in`、`contains`、`contains_key` 条件，不支持聚合属性，也不支持原地更新顶点或边的属性。
+
+### riscv64 平台说明
+
+在 Linux riscv64 上，RocksDB 的 JNI 库需要 `libatomic.so.1`。`bin/util.sh` 会查找该库并在
+`bin/hugegraph-server.sh`、`bin/init-store.sh` 和 `bin/dump-store.sh` 启动 JVM 之前把它加入
+`LD_PRELOAD`。如果找不到，这些脚本会以
+`RISC-V RocksDB requires libatomic.so.1; install libatomic1` 退出，安装 `libatomic1` 包即可解决。

--- a/content/en/docs/config/config-backend-rocksdb.md
+++ b/content/en/docs/config/config-backend-rocksdb.md
@@ -1,0 +1,302 @@
+---
+title: "Configuring the RocksDB Backend"
+linkTitle: "Config RocksDB Backend"
+weight: 5
+---
+
+### Overview
+
+RocksDB is an embedded LSM-tree key-value store. With the `rocksdb` backend, HugeGraph-Server keeps all
+graph data in RocksDB instances that live inside the server process, so there is no separate storage
+service to deploy. This is the backend used by the shipped `conf/graphs/hugegraph.properties`.
+
+Since version 1.7.0 the server accepts only `memory`, `rocksdb`, `hbase` and `hstore` as the backend.
+The `rocksdb` backend stores data on the local disks of one server: it does not support shared storage,
+so a graph cannot be served by several servers over the same data directory. For a distributed
+deployment use the `hstore` backend with PD and Store.
+
+The RocksDB JNI library is pinned to version `8.10.2` by `hugegraph-rocksdb/pom.xml`, so the on-disk
+format and the option semantics are those of RocksDB 8.10.
+
+The backend driver version reported by this store is `1.11`, and it is written into the meta table of
+the system store when the graph is initialized.
+
+### Selecting the backend
+
+Set the backend and the serializer in the graph properties file (`conf/graphs/<graph>.properties`):
+
+```properties
+gremlin.graph=org.apache.hugegraph.HugeFactory
+
+backend=rocksdb
+serializer=binary
+
+store=hugegraph
+
+# rocksdb backend config
+#rocksdb.data_path=/path/to/disk
+#rocksdb.wal_path=/path/to/disk
+```
+
+- `backend=rocksdb` selects the RocksDB store provider.
+- `serializer=binary` is the serializer the shipped template uses for this backend. The built-in
+  serializers are `binary`, `binaryscatter` and `text`.
+- `store` is the database namespace of the graph, and it is also part of the graph name that the
+  provider passes down to the store.
+
+Run `bin/init-store.sh` once before the first start to create the stores, then start the server. Both
+`bin/init-store.sh` and `bin/hugegraph-server.sh` load the RocksDB library, so the data directories are
+created on the machine that runs them.
+
+The distribution registers the option space and the store provider for each backend listed in the
+packaged `backend.properties`, whose value comes from the `hugegraph.backends` build property. A default
+build registers `rocksdb, hbase, hstore`; building with `-Drocksdb-only` activates the `rocksdb-only`
+profile and produces a distribution that registers only `rocksdb`. A backend that is not registered
+fails at startup with `Not exists BackendStoreProvider`.
+
+The provider registration also adds a second name, `rocksdbsst`, for the store that writes SST files
+instead of a live database. That name is not in the list of allowed backends, so `backend=rocksdbsst`
+is rejected with `backend is illegal: rocksdbsst`. To load SST files into a normal `rocksdb` graph, use
+`rocksdb.sst_path` as described below.
+
+### Data directory layout
+
+Two directories matter: `rocksdb.data_path` (default `rocksdb-data/data`) and `rocksdb.wal_path`
+(default `rocksdb-data/wal`). Relative paths resolve against the working directory of the server, which
+is the installation directory.
+
+Each graph opens three stores: `m` for schema, `g` for graph data, and `s` for the system store. The
+store name is appended to both configured paths, so a default single-graph installation looks like this:
+
+```
+rocksdb-data/
+  data/
+    m/    # schema store: property keys, vertex/edge/index labels, counters
+    g/    # graph store: vertices, edges, index tables, olap tables
+    s/    # system store: tasks, server info, backend meta (driver version)
+  wal/
+    m/
+    g/
+    s/
+```
+
+Every backend table becomes a RocksDB column family inside the store it belongs to, named
+`<database>+<table>`, where the database is derived from the graph name. Column families of existing
+data directories are always reopened, so tables created by an older version stay readable.
+
+Other points to keep in mind:
+
+- Two graphs must not share a data path. When a graph is created by cloning an existing configuration
+  through the API, the provider appends `_<newGraph>` to both `rocksdb.data_path` and
+  `rocksdb.wal_path`. Deleting such a graph deletes both directories.
+- Snapshots are created beside the data directory: the last two segments of the data path are rewritten
+  with a prefix, so with the default paths the snapshot of the graph store goes to
+  `rocksdb-data/<prefix>_data/g`. Resuming a snapshot closes the instance, deletes the data directory
+  and moves the snapshot into its place.
+- With `rocksdb.data_disks` set, the tables named there are opened as separate RocksDB instances under
+  the given paths instead of under `rocksdb.data_path`. The server opens up to 8 instances in parallel,
+  waits at most 600 seconds for the open to finish and 30 seconds for sessions to close.
+
+### Path and log options
+
+| config option        | default value       | description                                                                                                                                                                                                                                                                                                                                       |
+|----------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.data_path    | `rocksdb-data/data` | The path for storing data of RocksDB. Must not be empty.                                                                                                                                                                                                                                                                                          |
+| rocksdb.data_disks   | `[]`                | The optimized disks for storing data of RocksDB. The format of each element: `STORE/TABLE: /path/disk`. Allowed keys are [g/vertex, g/edge_out, g/edge_in, g/vertex_label_index, g/edge_label_index, g/range_int_index, g/range_float_index, g/range_long_index, g/range_double_index, g/secondary_index, g/search_index, g/shard_index, g/unique_index, g/olap]. A disk path must differ from `rocksdb.data_path`. |
+| rocksdb.wal_path     | `rocksdb-data/wal`  | The path for storing WAL of RocksDB. Must not be empty.                                                                                                                                                                                                                                                                                           |
+| rocksdb.sst_path     | (empty)             | The path for ingesting SST file into RocksDB. Empty disables ingestion.                                                                                                                                                                                                                                                                           |
+| rocksdb.log_level    | `INFO`              | The info log level of RocksDB. Allowed values: DEBUG, INFO, WARN, ERROR, FATAL, HEADER.                                                                                                                                                                                                                                                            |
+
+### Compaction and compression options
+
+| config option                  | default value                                                                             | description                                                                                                                                                    |
+|--------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.num_levels             | `7`                                                                                       | Set the number of levels for this database. Range: 1 to 2^31-1.                                                                                                |
+| rocksdb.compaction_style       | `LEVEL`                                                                                   | Set compaction style for RocksDB: LEVEL/UNIVERSAL/FIFO.                                                                                                        |
+| rocksdb.optimize_mode          | `true`                                                                                    | Optimize for heavy workloads and big datasets. See "How the options are applied" below.                                                                          |
+| rocksdb.bulkload_mode          | `false`                                                                                   | Switch to the mode to bulk load data into RocksDB.                                                                                                             |
+| rocksdb.compression_per_level  | `[none, none, snappy, snappy, snappy, snappy, snappy]`                                    | The compression algorithms for different levels of RocksDB, allowed values are none/snappy/z/bzip2/lz4/lz4hc/xpress/zstd. The list must be empty or hold exactly `rocksdb.num_levels` elements. |
+| rocksdb.bottommost_compression | `none`                                                                                    | The compression algorithm for the bottommost level of RocksDB, allowed values are none/snappy/z/bzip2/lz4/lz4hc/xpress/zstd.                                    |
+| rocksdb.compression            | `snappy`                                                                                  | The compression algorithm for compressing blocks of RocksDB, allowed values are none/snappy/z/bzip2/lz4/lz4hc/xpress/zstd.                                      |
+
+### Database level options
+
+| config option                          | default value        | description                                                                                                                                                                             |
+|----------------------------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.max_background_jobs            | `8`                  | Maximum number of concurrent background jobs, including flushes and compactions. Range: 1 to 2^31-1.                                                                                    |
+| rocksdb.max_subcompactions             | `4`                  | The value represents the maximum number of threads per compaction job. Range: 1 to 2^31-1.                                                                                              |
+| rocksdb.delayed_write_rate             | `16777216` (16 MB/s) | The rate limit in bytes/s of user write requests when need to slow down if the compaction gets behind.                                                                                   |
+| rocksdb.max_open_files                 | `-1`                 | The maximum number of open files that can be cached by RocksDB, -1 means no limit.                                                                                                       |
+| rocksdb.max_manifest_file_size         | `104857600` (100 MB) | The max size of manifest file in bytes.                                                                                                                                                 |
+| rocksdb.skip_stats_update_on_db_open   | `false`              | Whether to skip statistics update when opening the database, setting this flag true allows us to not update statistics.                                                                  |
+| rocksdb.skip_check_sst_size_on_db_open | `false`              | Whether to skip checking sizes of all sst files when opening the database.                                                                                                               |
+| rocksdb.max_file_opening_threads       | `16`                 | The max number of threads used to open files. Range: 1 to 2^31-1.                                                                                                                       |
+| rocksdb.max_total_wal_size             | `0`                  | Total size of WAL files in bytes. Once WALs exceed this size, we will start forcing the flush of column families related, 0 means no limit.                                              |
+| rocksdb.bytes_per_sync                 | `0`                  | Allows OS to incrementally sync SST files to disk while they are being written, asynchronously in the background. Issue one request for every bytes_per_sync written. 0 turns it off.     |
+| rocksdb.wal_bytes_per_sync             | `0`                  | Same as above for WAL files. 0 turns it off.                                                                                                                                            |
+| rocksdb.strict_bytes_per_sync          | `false`              | When true, guarantees SST/WAL files have at most bytes_per_sync/wal_bytes_per_sync bytes submitted for writeback at any given time. This can be used to handle cases where processing speed exceeds I/O speed. |
+| rocksdb.db_write_buffer_size           | `0`                  | Total size of write buffers in bytes across all column families, 0 means no limit.                                                                                                       |
+| rocksdb.log_readahead_size             | `0`                  | The number of bytes to prefetch when reading the log. 0 means the prefetching is disabled.                                                                                               |
+| rocksdb.compaction_readahead_size      | `0`                  | The number of bytes to perform bigger reads when doing compaction. If running RocksDB on spinning disks, you should set this to at least 2MB. 0 means the prefetching is disabled.        |
+| rocksdb.row_cache_capacity             | `0`                  | The capacity in bytes of global cache for table-level rows. 0 means the row_cache is disabled.                                                                                           |
+| rocksdb.delete_obsolete_files_period   | `21600` (6 hours)    | The periodicity in seconds when obsolete files get deleted, 0 means always do full purge. The value is converted to microseconds before it reaches RocksDB.                              |
+
+### Memtable options
+
+| config option                               | default value        | description                                                                                                                                                                                                                 |
+|---------------------------------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.write_buffer_size                   | `134217728` (128 MB) | Amount of data in bytes to build up in memory. Minimum 1 MB. This is per column family.                                                                                                                                     |
+| rocksdb.max_write_buffer_number             | `6`                  | The maximum number of write buffers that are built up in memory. Range: 1 to 2^31-1.                                                                                                                                        |
+| rocksdb.min_write_buffer_number_to_merge    | `2`                  | The minimum number of write buffers that will be merged together. Range: 1 to 2^31-1.                                                                                                                                       |
+| rocksdb.max_write_buffer_number_to_maintain | `0`                  | The total maximum number of write buffers to maintain in memory for conflict checking when transactions are used.                                                                                                            |
+| rocksdb.memtable_bloom_size_ratio           | `0.0`                | If prefix-extractor is set and memtable_bloom_size_ratio is not 0, or if memtable_whole_key_filtering is set true, create bloom filter for memtable with the size of write_buffer_size * memtable_bloom_size_ratio. A value larger than 0.25 is reduced to 0.25. Range: 0.0 to 1.0. |
+| rocksdb.memtable_whole_key_filtering        | `false`              | Enable whole key bloom filter in memtable, it can potentially reduce CPU usage for point-look-ups. Note this will only take effect if memtable_bloom_size_ratio > 0.                                                          |
+| rocksdb.memtable_huge_page_size             | `0`                  | The page size for huge page TLB for bloom in memtable. If <= 0, not allocate from huge page TLB but from malloc.                                                                                                             |
+| rocksdb.inplace_update_support              | `false`              | Allows thread-safe inplace updates if a put key exists in current memtable and sizeof new value is smaller.                                                                                                                  |
+
+### Level sizing and write stall options
+
+| config option                               | default value             | description                                                                                                                                                                                                                                            |
+|---------------------------------------------|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.level_compaction_dynamic_level_bytes | `false`                  | Whether to enable level_compaction_dynamic_level_bytes, if it's enabled we give max_bytes_for_level_multiplier a priority against max_bytes_for_level_base, the bytes of base level is dynamic for a more predictable LSM tree, it is useful to limit worse case space amplification. Turning this feature on/off for an existing DB can cause unexpected LSM tree structure so it's not recommended. |
+| rocksdb.max_bytes_for_level_base            | `536870912` (512 MB)      | The upper-bound of the total size of level-1 files in bytes. Minimum 1 MB.                                                                                                                                                                             |
+| rocksdb.max_bytes_for_level_multiplier      | `10.0`                    | The ratio between the total size of level (L+1) files and the total size of level L files for all L. Minimum 1.0.                                                                                                                                       |
+| rocksdb.target_file_size_base               | `67108864` (64 MB)        | The target file size for compaction in bytes. Minimum 1 MB.                                                                                                                                                                                             |
+| rocksdb.target_file_size_multiplier         | `1`                       | The size ratio between a level L file and a level (L+1) file.                                                                                                                                                                                           |
+| rocksdb.level0_file_num_compaction_trigger  | `2`                       | Number of files to trigger level-0 compaction.                                                                                                                                                                                                         |
+| rocksdb.level0_slowdown_writes_trigger      | `20`                      | Soft limit on number of level-0 files for slowing down writes.                                                                                                                                                                                          |
+| rocksdb.level0_stop_writes_trigger          | `36`                      | Hard limit on number of level-0 files for stopping writes.                                                                                                                                                                                             |
+| rocksdb.soft_pending_compaction_bytes_limit | `68719476736` (64 GB)     | The soft limit to impose on pending compaction in bytes. Minimum 1 GB.                                                                                                                                                                                  |
+| rocksdb.hard_pending_compaction_bytes_limit | `274877906944` (256 GB)   | The hard limit to impose on pending compaction in bytes. Minimum 1 GB.                                                                                                                                                                                  |
+
+### File I/O options
+
+| config option                                  | default value | description                                                                                                                                                     |
+|------------------------------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.allow_mmap_writes                      | `false`       | Allow the OS to mmap file for writing.                                                                                                                          |
+| rocksdb.allow_mmap_reads                       | `false`       | Allow the OS to mmap file for reading sst tables.                                                                                                                |
+| rocksdb.use_direct_reads                       | `false`       | Enable the OS to use direct I/O for reading sst tables.                                                                                                          |
+| rocksdb.use_direct_io_for_flush_and_compaction | `false`       | Enable the OS to use direct read/writes in flush and compaction.                                                                                                 |
+| rocksdb.use_fsync                              | `false`       | If true, then every store to stable storage will issue a fsync.                                                                                                 |
+| rocksdb.atomic_flush                           | `false`       | If true, flushing multiple column families and committing their results atomically to MANIFEST. Note that it's not necessary to set atomic_flush=true if WAL is always enabled. |
+
+### SST table format and block cache options
+
+| config option                            | default value          | description                                                                                                                                                                          |
+|------------------------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.format_version                   | `5`                    | The format version of BlockBasedTable, allowed values are 0~5.                                                                                                                        |
+| rocksdb.index_type                       | `kBinarySearch`        | The index type used to lookup between data blocks with the sst table, allowed values are [kBinarySearch, kHashSearch, kTwoLevelIndexSearch, kBinarySearchWithFirstKey].                |
+| rocksdb.data_block_index_type            | `kDataBlockBinarySearch` | The search type used to point lookup in data block with the sst table, allowed values are [kDataBlockBinarySearch, kDataBlockBinaryAndHash].                                        |
+| rocksdb.data_block_hash_table_util_ratio | `0.75`                 | The hash table utilization ratio value of entries/buckets. It is valid only when data_block_index_type=kDataBlockBinaryAndHash. Range: 0.0 to 1.0.                                    |
+| rocksdb.block_size                       | `4096` (4 KB)          | Approximate size of user data packed per block, Note that it corresponds to uncompressed data.                                                                                        |
+| rocksdb.block_size_deviation             | `10`                   | The percentage of free space used to close a block. Range: 0 to 100.                                                                                                                  |
+| rocksdb.block_restart_interval           | `16`                   | The block restart interval for delta encoding in blocks.                                                                                                                              |
+| rocksdb.block_cache_capacity             | `8388608` (8 MB)       | The amount of block cache in bytes that will be used by RocksDB, 0 means no block cache. A separate cache of this size is created for each column family.                              |
+
+### Bloom filter options
+
+The options in this group are read only when `rocksdb.bloom_filter_bits_per_key` is 0 or greater. With
+the default value of -1 there is no bloom filter and none of the other options in this table take
+effect, including the index and filter block caching ones.
+
+| config option                                   | default value | description                                                                                                                                                                                                       |
+|-------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rocksdb.bloom_filter_bits_per_key               | `-1`          | The bits per key in bloom filter, a good value is 10, which yields a filter with ~ 1% false positive rate. Set bloom_filter_bits_per_key > 0 to enable bloom filter, -1 means no bloom filter (0~0.5 round down to no filter). |
+| rocksdb.bloom_filter_block_based_mode           | `false`       | If bloom filter is enabled, set this option true to use block based filter rather than full filter.                                                                                                                |
+| rocksdb.bloom_filter_whole_key_filtering        | `true`        | If bloom filter is enabled, set this option true to place whole keys in the bloom filter, else place the prefix of keys when prefix-extractor is set.                                                               |
+| rocksdb.cache_index_and_filter_blocks           | `true`        | Set this option true if we'd put index/filter blocks to the block cache.                                                                                                                                          |
+| rocksdb.pin_l0_filter_and_index_blocks_in_cache | `true`        | Set this option true if we'd pin L0 index/filter blocks to the block cache.                                                                                                                                       |
+| rocksdb.optimize_filters_for_hits               | `true`        | If bloom filter is enabled, this flag allows us to not store filters for the last level. set this option true to optimize the filters mainly for cases where keys are found rather than also optimize for keys missed. This one is applied even when the filter is disabled. |
+| rocksdb.partition_filters_and_indexes           | `false`       | If bloom filter is enabled, set this option true to use partitioned full filters and indexes for each sst file. This option is incompatible with block-based filters. Enabling it also forces the index type to kTwoLevelIndexSearch and sets the metadata block size to `rocksdb.block_size`. |
+| rocksdb.pin_top_level_index_and_filter          | `true`        | If partition_filters_and_indexes is set true, set this option true if we'd pin top-level index of partitioned filter and index blocks to the block cache.                                                          |
+| rocksdb.prefix_extractor_n_bytes                | `0`           | The prefix-extractor uses the first N bytes of a key as its prefix, it will use the full key when a key is shorter than the N. 0 means unset prefix-extractor.                                                       |
+
+### How the options are applied
+
+The server builds the RocksDB option objects once per store and per column family, so a change to any
+of the options above takes effect on the next server start.
+
+- `rocksdb.optimize_mode=true` applies presets before the values in the tables above: at the database
+  level it raises parallelism to half of the available processors (at least one), allows concurrent
+  memtable writes and enables the write thread adaptive yield; at the column family level it calls the
+  RocksDB level-style and universal-style compaction presets. The explicit options are applied
+  afterwards, so any value you set in the properties file wins over the preset.
+- `rocksdb.bulkload_mode=true` disables automatic compaction, raises the three level-0 triggers to the
+  maximum integer and the two pending compaction limits to the maximum long value. Turn it off and
+  restart after the load, otherwise compaction never runs.
+- `rocksdb.block_cache_capacity=0` turns the block cache off completely rather than making it unbounded.
+- `rocksdb.prefix_extractor_n_bytes` greater than 0 installs a capped prefix extractor of that length.
+- Every column family uses the `uint64add` merge operator, which is what the counter table relies on.
+- The database is created if it is missing, and `avoid_unnecessary_blocking_io` and
+  `write_dbid_to_manifest` are always on.
+
+### Memory notes
+
+The caches and write buffers of RocksDB are native allocations, so they are not part of the JVM heap
+sizing in `bin/hugegraph-server.sh`. The `GET /metrics/backend` endpoint reports what the store uses:
+the memory number is the sum of the block cache usage, the pinned block cache usage, the estimated
+table reader memory (index and filter blocks) and the size of all memtables, taken from the RocksDB
+properties of every open column family.
+
+Two option values multiply with the number of column families:
+
+- `rocksdb.block_cache_capacity` creates one cache instance per column family, so the total block cache
+  of a server is roughly this value times the number of open tables across the `m`, `g` and `s` stores
+  of every graph, plus the instances opened for `rocksdb.data_disks`.
+- `rocksdb.write_buffer_size` times `rocksdb.max_write_buffer_number` bounds the memtable memory of one
+  column family. `rocksdb.db_write_buffer_size` caps the total across all column families of one store,
+  and its default of 0 means there is no such cap.
+
+`rocksdb.row_cache_capacity` is different: it is one cache per store, and 0 disables it.
+
+### Ingesting SST files
+
+Setting `rocksdb.sst_path` turns on ingestion. When a store is opened, and again whenever tables are
+created, the server walks `<sst_path>/<column family>/`, collects every non-empty `*.sst` file below it
+and ingests those files into the matching column family. The files are moved rather than copied, so the
+source directory is consumed by the ingestion.
+
+### Raft mode
+
+The RocksDB backend can still run behind the raft state machine: with `raft.mode=true` the store
+provider of any local backend is wrapped by the raft provider. The wrapper rejects backends with shared
+storage, so `rocksdb` is accepted while `hbase` is not. Under raft mode a RocksDB session writes with
+the WAL disabled and without sync, because the state machine can restore from a snapshot plus the raft
+log, and snapshots are supported by this backend.
+
+Notes for anyone using it:
+
+- `bin/init-store.sh` forces `raft.mode=false` while it initializes the backend, so initialization never
+  goes through raft.
+- The shipped `conf/graphs/hugegraph.properties` marks the raft options as deprecated. Distributed
+  deployments of 1.7.0 and later use the `hstore` backend with PD and Store instead.
+- The raft peer endpoints are served under `graphspaces/{graphspace}/graphs/{graph}/raft/`, with
+  `list_peers`, `get_leader`, `set_leader`, `transfer_leader`, `add_peer` and `remove_peer`.
+  `bin/raft-tools.sh` wraps the same operations, but it still builds URLs without the graphspace
+  segment, so the path has to be adjusted for a 1.7.0 server.
+- The remaining `raft.*` options are listed in the
+  [Server Complete Configuration Manual](config-option).
+
+### Backend capabilities
+
+The feature flags of this backend affect what the server can push down to the store:
+
+- Scans by key prefix and by key range, paged queries, range conditions and order-by are supported.
+- There is no index inside RocksDB, so querying schema by name, querying by label and deleting edges by
+  label are done by the server instead of the store.
+- Transactions are supported through RocksDB write batches.
+- Snapshots are supported, which is what raft mode and backup rely on.
+- Shared storage is not supported, so one data directory belongs to one server.
+- Olap properties are supported, and their tables are created as extra column families.
+- The store does not expire data by itself, so the server filters out elements whose TTL has passed when
+  it reads them.
+- `in`, `contains` and `contains_key` conditions, aggregate properties and vertex or edge property
+  updates in place are not supported at the store level.
+
+### Platform note for riscv64
+
+On Linux riscv64 the RocksDB JNI library needs `libatomic.so.1`. `bin/util.sh` looks for it and adds it
+to `LD_PRELOAD` before `bin/hugegraph-server.sh`, `bin/init-store.sh` and `bin/dump-store.sh` start the
+JVM. If it is missing, those scripts stop with
+`RISC-V RocksDB requires libatomic.so.1; install libatomic1`, and installing the `libatomic1` package
+fixes it.


### PR DESCRIPTION
The RocksDB backend had no page of its own: `config-option.md` lists a subset of the `rocksdb.*` keys and
`config-guide.md` mentions two of them, so nothing documented the data directory layout, the option
groups, how `optimize_mode` and `bulkload_mode` behave, the memory accounting, SST ingestion, the state
of raft mode for this backend or the pinned RocksDB version. This adds the page in English and Chinese,
built from the sources on hugegraph master (commit 36811483a).

| page | what was wrong | what changed | source (file:line on master) |
|------|----------------|--------------|------------------------------|
| config/config-backend-rocksdb.md (en, cn) | Page did not exist | New page, frontmatter and layout follow `config-https.md`, weight 5 places it after `config-option` | n/a |
| config/config-backend-rocksdb.md | Nothing documented what the backend is or which backends 1.7.0 accepts | Overview: embedded LSM store inside the server process, allowed backends are memory, rocksdb, hbase, hstore, no shared storage so use hstore for distributed setups | hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/store/BackendProviderFactory.java:37-48; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBFeatures.java:25-27 |
| config/config-backend-rocksdb.md | RocksDB version was documented nowhere | States rocksdbjni is pinned to 8.10.2 | hugegraph-server/hugegraph-rocksdb/pom.xml:37-41 |
| config/config-backend-rocksdb.md | Backend selection was only implicit in the guide | `backend=rocksdb`, `serializer=binary`, `store`, plus `init-store.sh` before the first start | hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties:22-32; hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/SerializerFactory.java:34-43 |
| config/config-backend-rocksdb.md | Provider registration and the `rocksdbsst` name were undocumented | Registration comes from the packaged `backend.properties` (`hugegraph.backends`, default rocksdb/hbase/hstore, `-Drocksdb-only` for a rocksdb-only build); `rocksdbsst` is registered but rejected by the allowed backend list | hugegraph-server/hugegraph-dist/src/main/java/org/apache/hugegraph/dist/RegisterUtil.java:57-117; hugegraph-server/hugegraph-dist/src/main/resources/backend.properties:18; hugegraph-server/hugegraph-dist/pom.xml:38,294-304; hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/store/BackendProviderFactory.java:48,74-77 |
| config/config-backend-rocksdb.md | Data directory layout was undocumented | data_path and wal_path defaults, the `m`/`g`/`s` store subdirectories, one column family per table named `<database>+<table>`, old column families always reopened | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java:301-305,384-393; hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/store/BackendStoreProvider.java:28-30; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBTable.java:64; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java:388-391 |
| config/config-backend-rocksdb.md | Multi-graph and snapshot paths were undocumented | Graphs cannot share a data path, cloned configs get a `_<newGraph>` suffix, deleting a graph deletes both dirs, snapshot path shape and resume behavior, parallel open of up to 8 instances with 600s/30s timeouts | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStoreProvider.java:43-64; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java:97-104,209-253,686-757 |
| config/config-backend-rocksdb.md | Only 47 of the 70 `rocksdb.*` keys were documented anywhere, and three defaults were wrong | All 70 keys with defaults, ranges and allowed values, in eight tables that keep the declaration order of the Options class | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBOptions.java:56-699 |
| config/config-backend-rocksdb.md | How the options reach RocksDB was undocumented | optimize_mode presets applied before the explicit options, bulkload_mode effects, block cache 0 means no cache, capped prefix extractor, `uint64add` merge operator, create-if-missing and the two always-on flags | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java:446-694 |
| config/config-backend-rocksdb.md | The bloom filter group looked unconditional | Notes that the filter and index caching options are only read when `bloom_filter_bits_per_key >= 0`, and that `optimize_filters_for_hits` applies regardless | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java:560,667-691 |
| config/config-backend-rocksdb.md | No memory guidance existed | What `GET /metrics/backend` counts as memory, block cache is per column family, write buffers are per column family with `db_write_buffer_size` as the per store cap, row cache is per store | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBMetrics.java:159-167; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java:494-502,577-578,659-665; hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/metrics/MetricsAPI.java:85,115 |
| config/config-backend-rocksdb.md | `rocksdb.sst_path` had a one line description and no behavior | Ingestion walks `<sst_path>/<column family>/`, takes non-empty `*.sst` files and moves them into the column family | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java:351-366; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBIngester.java:34-52 |
| config/config-backend-rocksdb.md | Raft mode for rocksdb was undocumented | The raft wrapper accepts only backends without shared storage, sessions write with WAL and sync off, init-store forces `raft.mode=false`, the shipped template marks the raft options deprecated, and the peer endpoints now live under `graphspaces/{graphspace}/graphs/{graph}/raft/` | hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/store/BackendProviderFactory.java:63-70; hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/store/raft/RaftBackendStoreProvider.java:83-87; hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java:715-723; hugegraph-server/hugegraph-dist/src/main/java/org/apache/hugegraph/cmd/InitStore.java:283-284; hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties:59-60; hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/raft/RaftAPI.java:57 |
| config/config-backend-rocksdb.md | Backend feature limits were undocumented | Supported scans and paging, no store side index, write batch transactions, snapshots, no shared storage, olap tables, TTL filtered by the server, unsupported conditions and property updates | hugegraph-server/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBFeatures.java:25-145 |
| config/config-backend-rocksdb.md | The riscv64 requirement was undocumented | `libatomic.so.1` is preloaded by `bin/util.sh` for the server, init-store and dump-store scripts, with the exact error message | hugegraph-server/hugegraph-dist/src/assembly/static/bin/util.sh:27-63; hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh:48 |

Follow-up outside this PR: the page is not yet listed in `data/docs_nav.json` or in the section index of
`config/_index.md`, both of which are shared files that several backend pages need to touch at once.
