### PR TITLE
doc(server): sync dist with master

### DIFF
--- a/content/cn/docs/clients/gremlin-console.md
+++ b/content/cn/docs/clients/gremlin-console.md
@@ -109,41 +109,33 @@ serializer: {
 }
 ```
 
+如果 Server 开启了鉴权模式，需要在同一个文件中补上凭据：
+
+```yaml
+username: admin
+password: pa
+```
+
+`conf` 目录下还提供了 `remote-objects.yaml` 和 `gremlin-driver-settings.yaml`，它们使用相同的 host、port 和序列化器配置。
+
 ```groovy
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
 ==>Configured localhost/127.0.0.1:8182
 ```
 
-连接成功之后，如果在启动 HugeGraph-Server 的过程中导入了示例图，就可以在 Gremlin-Console 中直接进行查询：
+Server 端的图以图空间限定名绑定，因此图空间 `DEFAULT` 下的图 `hugegraph` 绑定名为 `DEFAULT-hugegraph`，其 traversal source 绑定名为 `__g_DEFAULT-hugegraph`。裸写 `hugegraph` 在 Server 端无法解析，而 `DEFAULT-hugegraph` 又不是合法的 Groovy 标识符，所以远程脚本需要通过别名访问 traversal source。如果启动 HugeGraph-Server 时预加载了示例图，查询方式如下：
 
 ```groovy
-gremlin> :> hugegraph.traversal().V()
-==>[id:2:lop,label:software,type:vertex,properties:[name:lop,lang:java,price:328]]
-==>[id:1:josh,label:person,type:vertex,properties:[name:josh,age:32,city:Beijing]]
-==>[id:1:marko,label:person,type:vertex,properties:[name:marko,age:29,city:Beijing]]
-==>[id:1:peter,label:person,type:vertex,properties:[name:peter,age:35,city:Shanghai]]
-==>[id:1:vadas,label:person,type:vertex,properties:[name:vadas,age:27,city:Hongkong]]
-==>[id:2:ripple,label:software,type:vertex,properties:[name:ripple,lang:java,price:199]]
-```
-
-> 注意：在 Client/Server 模式下，所有和 Server 有关的操作都要加上 `:> `，如果不加，表示在 console 本地操作。
-
-还可以把多条语句放在一个字符串变量中，然后一次性发给 Server：
-
-```groovy
-gremlin> script = """
-......1> graph = hugegraph;
-......2> g = graph.traversal();
-......3> g.V().toList().size();
-......4> """
-==>
-graph = hugegraph;
-g = graph.traversal();
-g.V().toList().size();
-
-gremlin> :> @script
+gremlin> import org.apache.tinkerpop.gremlin.driver.Cluster
+gremlin> cluster = Cluster.open('conf/remote.yaml')
+gremlin> client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
+gremlin> client.submit('g.V().count()').all().get()[0].object
 ==>6
-gremlin> 
+gremlin> client.submit('g.V().toList().size()').all().get()[0].object
+==>6
+gremlin> client.close(); cluster.close()
 ```
+
+> 注意：在 Client/Server 模式下，所有和 Server 有关的操作都要加上 `:> `，如果不加，表示在 console 本地操作。`:> ` 发送的脚本不带别名，因此只能使用 Server 自身已绑定的名称。
 
 更多关于 Gremlin-Console 的使用，请参考 [Tinkerpop 官网](http://tinkerpop.apache.org/docs/current/reference/)。

--- a/content/cn/docs/config/config-guide.md
+++ b/content/cn/docs/config/config-guide.md
@@ -48,6 +48,8 @@ scriptEngines: {
           org.apache.hugegraph.backend.id.IdGenerator,
           org.apache.hugegraph.type.define.Directions,
           org.apache.hugegraph.type.define.NodeRole,
+          org.apache.hugegraph.masterelection.GlobalMasterInfo,
+          org.apache.hugegraph.util.DateUtil,
           org.apache.hugegraph.traversal.algorithm.CollectionPathsTraverser,
           org.apache.hugegraph.traversal.algorithm.CountTraverser,
           org.apache.hugegraph.traversal.algorithm.CustomizedCrosspointsTraverser,
@@ -72,7 +74,6 @@ scriptEngines: {
           org.apache.hugegraph.traversal.optimize.ConditionP,
           org.apache.hugegraph.traversal.optimize.Text,
           org.apache.hugegraph.traversal.optimize.TraversalUtil,
-          org.apache.hugegraph.util.DateUtil,
           org.opencypher.gremlin.traversal.CustomFunctions,
           org.opencypher.gremlin.traversal.CustomPredicate
         ],
@@ -138,9 +139,9 @@ ssl: {
 
 - channelizer：默认的 `WsAndHttpChannelizer` 同时支持 WebSocket 和 HTTP。Gremlin-Console 使用 WebSocket，HugeGraph-Client、Loader 和 Hubble 使用 HTTP；
 
-默认 GremlinServer 是服务在 localhost:8182，如果需要修改，配置 host、port 即可
+默认 GremlinServer 是服务在 127.0.0.1:8182，如果需要修改，配置 host、port 即可
 
-- host：部署 GremlinServer 机器的机器名或 IP，目前 HugeGraphServer 不支持分布式部署，且 GremlinServer 不直接暴露给用户;
+- host：部署 GremlinServer 机器的机器名或 IP，GremlinServer 不直接暴露给用户，由 RestServer 转发 Gremlin 请求;
 - port：部署 GremlinServer 机器的端口；
 
 同时需要在 rest-server.properties 中增加对应的配置项 gremlinserver.url=http://host:port
@@ -155,7 +156,7 @@ ssl: {
 restserver.url=http://127.0.0.1:8080
 #restserver.enable_graphspaces_filter=false
 # gremlin server url, need to be consistent with host and port in gremlin-server.yaml
-#gremlinserver.url=http://127.0.0.1:8182
+#gremlinserver.url=127.0.0.1:8182
 
 graphs=./conf/graphs
 graph.load_from_local_config=true
@@ -195,32 +196,40 @@ memory_monitor.period=2000
 
 > 当前上游模板中的 Arthas 键仍写作 `arthas.telnet_port`、`arthas.http_port` 和 `arthas.disabled_commands`，但 `ServerOptions` 读取的是下方示例中的 camelCase 名称。自定义配置应使用 `arthas.telnetPort`、`arthas.httpPort` 和 `arthas.disabledCommands`。
 
-> 配置项 gremlinserver.url 是 GremlinServer 为 RestServer 提供服务的 url，该配置项默认为 http://localhost:8182，如需修改，需要和 gremlin-server.yaml 中的 host 和 port 相匹配；
+> 配置项 gremlinserver.url 是 GremlinServer 为 RestServer 提供服务的 url，该配置项默认为 http://127.0.0.1:8182，如需修改，需要和 gremlin-server.yaml 中的 host 和 port 相匹配；该值可以像模板那样省略协议前缀，缺失时会自动补上 `http://`。
 
 ### 4 hugegraph.properties
 
 hugegraph.properties 是一类文件，因为如果系统存在多个图，则会有多个相似的文件。该文件用来配置与图存储和查询相关的参数，文件的默认内容如下：
 
 ```properties
-# gremlin entrence to create graph
+# gremlin entrance to create graph
+# auth config: org.apache.hugegraph.auth.HugeFactoryAuthProxy
 gremlin.graph=org.apache.hugegraph.HugeFactory
 
 # cache config
 #schema.cache_capacity=100000
 # vertex-cache default is 1000w, 10min expired
+vertex.cache_type=l2
 #vertex.cache_capacity=10000000
 #vertex.cache_expire=600
 # edge-cache default is 100w, 10min expired
+edge.cache_type=l2
 #edge.cache_capacity=1000000
 #edge.cache_expire=600
 
+
 # schema illegal name template
 #schema.illegal_name_regex=\s+|~.*
+
+#vertex.default_label=vertex
 
 # NOTE: since 1.7.0, only hstore, rocksdb, hbase, memory are supported for backend.
 # if you want to use Cassandra/MySql/PG... as backend, please use version < 1.7.0
 backend=rocksdb
 serializer=binary
+# The process-wide max capacity of one serialization buffer in bytes
+#serializer.buffer_max_capacity=134217728
 
 store=hugegraph
 
@@ -232,7 +241,7 @@ task.schedule_period=10
 task.retry=0
 task.wait_timeout=10
 
-# if use 'ikanalyzer', need download jar from 'https://github.com/apache/hugegraph-doc/raw/ik_binary/dist/server/ikanalyzer-2012_u6.jar' to lib directory
+# search config
 search.text_analyzer=jieba
 search.text_analyzer_mode=INDEX
 
@@ -245,17 +254,34 @@ search.text_analyzer_mode=INDEX
 #hbase.port=2181
 #hbase.znode_parent=/hbase
 #hbase.threads_max=64
+# IMPORTANT: recommend to modify the HBase partition number
+#            by the actual/env data amount & RS amount before init store
+#            It will influence the load speed a lot
+#hbase.enable_partition=true
+#hbase.vertex_partitions=10
+#hbase.edge_partitions=30
 
+# WARNING: These raft configurations are deprecated, please use the latest version instead.
+# raft.mode=false
+
+# memory management config
+#memory.mode=off-heap
+#memory.max_capacity=1073741824
+#memory.one_query_max_capacity=104857600
+#memory.alignment=8
 ```
 
 重点关注未注释的几项：
 
-- gremlin.graph：GremlinServer 的启动入口，用户不要修改此项；
+- gremlin.graph：GremlinServer 的启动入口，用户不要修改此项；开启鉴权时才改为 `org.apache.hugegraph.auth.HugeFactoryAuthProxy`；
+- vertex.cache_type / edge.cache_type：缓存实现，可选值为 `l1` 和 `l2`，默认 `l2`；
 - backend：使用的后端存储。1.7.0 支持 memory、rocksdb、hstore 和 hbase；
 - serializer：schema、vertex 和 edge 写入后端时使用的序列化器。RocksDB 使用 binary；
 - store：图在后端使用的存储名称；
-- rocksdb.data_path：backend 为 rocksdb 时此项才有意义，rocksdb 的数据目录
-- rocksdb.wal_path：backend 为 rocksdb 时此项才有意义，rocksdb 的日志目录
+- task.schedule_period、task.retry、task.wait_timeout：异步任务的调度周期（秒）、重试次数和等待超时（秒）。调度器由后端决定，`hstore` 使用分布式调度器，其余后端使用本地调度器；旧的 `task.scheduler_type` 键已被忽略；
+- search.text_analyzer / search.text_analyzer_mode：全文索引使用的分词器及其模式。可选分词器为 `ansj`、`hanlp`、`smartcn`、`jieba`、`jcseg`、`mmseg4j` 和 `ikanalyzer`，每种分词器有各自的模式取值；
+- rocksdb.data_path：backend 为 rocksdb 时此项才有意义，rocksdb 的数据目录，默认为 `rocksdb-data/data`
+- rocksdb.wal_path：backend 为 rocksdb 时此项才有意义，rocksdb 的日志目录，默认为 `rocksdb-data/wal`
 
 ### 5 多图配置
 
@@ -316,8 +342,8 @@ Initialization finished.
 ```bash
 $ ./bin/start-hugegraph.sh
 
-Starting HugeGraphServer...
-Connecting to HugeGraphServer (http://127.0.0.1:8080/graphspaces/DEFAULT/graphs)...OK
+Starting HugeGraphServer in daemon mode...
+Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)...OK
 Started [pid 21614]
 ```
 

--- a/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/cn/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -30,12 +30,14 @@ git clone https://github.com/apache/hugegraph.git
 为了避免配置文件的更改影响 Git 的追踪，建议将所需的配置文件拷贝到一个单独的文件夹中：
 
 ```bash
-cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf path-to-your-directory
+cp -r hugegraph-server/hugegraph-dist/src/assembly/static/scripts \
+      hugegraph-server/hugegraph-dist/src/assembly/static/conf \
+      path-to-your-directory
 ```
 
-将 `path-to-your-directory` 替换为你创建的文件夹的路径。
+将 `path-to-your-directory` 替换为你创建的文件夹的路径。命令需在仓库根目录执行，`hugegraph-dist` 模块位于顶层的 `hugegraph-server` 目录之下。
 
-> 在引入 ToplingDB 后，开发者需执行 `preload-topling.sh` 脚本，该脚本会将相关动态库和 Web Server 所需的静态资源自动解压至与 `bin` 同级的 `library` 目录中 (静态资源会同时拷贝到 `/dev/shm/rocksdb_resource` 中)。
+> ToplingDB 不在 `master` 的发布包中。在包含它的构建里，开发者需执行 `preload-topling.sh` 脚本，该脚本会将相关动态库和 Web Server 所需的静态资源自动解压至与 `bin` 同级的 `library` 目录中 (静态资源会同时拷贝到 `/dev/shm/rocksdb_resource` 中)。
 
 #### 2. `InitStore` 类初始化图
 
@@ -53,11 +55,11 @@ rocksdb.wal_path=.
 - 在 `Use classpath of module` 中选择 `hugegraph-dist`
 - 将 `Main class` 设置为 `org.apache.hugegraph.cmd.InitStore`
 - 设置运行参数为 `conf/rest-server.properties`，这里的路径是相对于工作路径的，需要将工作路径设置为 `path-to-your-directory`
-- (可选) ToplingDB 需要通过 `LD_PRELOAD` 机制预加载动态库，开发者需设置两个环境变量：`LD_LIBRARY_PATH` 指向 `preload-topling.sh` 解压出的 `library` 目录，`LD_PRELOAD` 设置为 `libjemalloc.so:librocksdbjni-linux64.so`，以确保相关库在运行时被正确加载
+- (可选，仅 ToplingDB 构建) ToplingDB 需要通过 `LD_PRELOAD` 机制预加载动态库，开发者需设置两个环境变量：`LD_LIBRARY_PATH` 指向 `preload-topling.sh` 解压出的 `library` 目录，`LD_PRELOAD` 设置为 `libjemalloc.so:librocksdbjni-linux64.so`，以确保相关库在运行时被正确加载
   - LD_LIBRARY_PATH=/path/to/your/library:$LD_LIBRARY_PATH
   - LD_PRELOAD=libjemalloc.so:librocksdbjni-linux64.so
 
-> 若在 **Java 11** 环境下为 HugeGraph-Server 配置了**用户认证** (authenticator)，需要参考二进制包的脚本[配置](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/init-store.sh#L52)，添加下述 **VM options**:
+> 若在 **Java 11** 环境下为 HugeGraph-Server 配置了**用户认证** (authenticator)，需要参考二进制包的脚本[配置](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/init-store.sh#L49)，添加下述 **VM options**:
 >
 > ```bash
 > --add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED
@@ -93,7 +95,9 @@ rocksdb.wal_path=.
 - 将 `Main class` 设置为 `org.apache.hugegraph.dist.HugeGraphServer`
 - 设置运行参数为 `conf/gremlin-server.yaml conf/rest-server.properties`，同样地，这里的路径是相对于工作路径的，需要将工作路径设置为 `path-to-your-directory`
 
-> 类似的，若在 **Java 11** 环境下为 HugeGraph-Server 配置了**用户认证** (authenticator)，同样需要参考二进制包的脚本[配置](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh#L124)，添加下述 **VM options**:
+> 二进制包中的 `bin/hugegraph-server.sh` 并不直接启动该类，而是启动 `org.apache.hugegraph.bootstrap.HugeGraphServerBootstrap`：它在两个配置文件路径之前多接收一个 `true`/`false` 的安全检查开关，为 `true` 时安装 `HugeSecurityManager`，随后再交给 `HugeGraphServer`。从 IDEA 直接运行 `HugeGraphServer` 会跳过这层包装，因此不会安装 security manager，这通常正是调试时想要的效果。
+
+> 类似的，若在 **Java 11** 环境下为 HugeGraph-Server 配置了**用户认证** (authenticator)，同样需要参考二进制包的脚本[配置](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh#L132)，添加下述 **VM options**:
 >
 > ```bash
 > --add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED --add-modules=jdk.unsupported --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
@@ -135,7 +139,7 @@ curl "http://localhost:8080/graphspaces/DEFAULT/graphs/hugegraph/graph/vertices"
 
 #### 5. Log4j2 日志配置
 
-默认情况下，运行 `InitStore` 和 `HugeGraphServer` 时，读取的 Log4j2 配置文件路径为 `hugegraph-dist/src/main/resources/log4j2.xml`，而不是 `path-to-your-directory/conf/log4j2.xml`，这个配置文件是使用**脚本**启动 HugeGraph-Server 时读取的。
+默认情况下，运行 `InitStore` 和 `HugeGraphServer` 时，读取的 Log4j2 配置文件路径为 `hugegraph-server/hugegraph-dist/src/main/resources/log4j2.xml`，而不是 `path-to-your-directory/conf/log4j2.xml`，这个配置文件是使用**脚本**启动 HugeGraph-Server 时读取的。
 
 为了避免同时维护两份配置文件，可以考虑在 **IntelliJ IDEA** 运行与调试 HugeGraph-Server 时，修改读取的 Log4j2 配置文件路径：
 

--- a/content/cn/docs/guides/hugegraph-docker-cluster.md
+++ b/content/cn/docs/guides/hugegraph-docker-cluster.md
@@ -18,34 +18,74 @@ HugeGraph 通过 Docker-Compose 可快速运行完整的分布式集群版（PD 
 
 ## Compose 文件
 
-在 HugeGraph 主仓库 [`docker/`](https://github.com/apache/hugegraph/tree/master/docker) 目录下提供了三个 compose 文件：
+在 HugeGraph 主仓库 [`docker/`](https://github.com/apache/hugegraph/tree/master/docker) 目录下提供了四个 compose 文件：
 
-| 文件 | 描述 |
-|------|------|
-| `docker-compose.yml` | 使用预构建镜像的** 1x3 单进程(节点)**快速启动 |
-| `docker-compose.dev.yml` | 从源码构建的单节点**开发模式** |
-| `docker-compose-3pd-3store-3server.yml` | ** 3x3 进程**(模拟节点)分布式集群 |
+| 文件 | 服务 | 适用场景 |
+|------|------|----------|
+| `docker-compose.yml` | 1 个 RocksDB Server + 1 个 Hubble | 默认的单机快速启动，推荐从这里开始 |
+| `docker-compose-hstore.yml` | 1 PD + 1 Store + 1 Server + 1 Hubble | 分布式本地开发 |
+| `docker-compose-3pd-3store-3server.yml` | 3 PD + 3 Store + 3 Server + 1 Hubble | HA 参考与评估 |
+| `docker-compose.dev.yml` | （仅覆盖文件） | 最小 HStore 拓扑的源码构建覆盖，始终与 `docker-compose-hstore.yml` 一起使用 |
+
+单机拓扑使用 `hugegraph/hugegraph:${HUGEGRAPH_VERSION:-latest}`；HStore 拓扑使用对应的 `hugegraph/pd`、`hugegraph/store` 和 `hugegraph/server` tag。Hubble 由 `${HUBBLE_IMAGE:-hugegraph/hubble:latest}` 单独选择。
 
 > 注: 后续步骤皆为假设你本地**已拉取** `hugegraph` 主仓库代码 (至少是 docker 目录)
+
+## 鉴权环境
+
+所有拓扑都从 Compose 环境读取管理员密码和共享 JWT 密钥，通常放在 `docker/.env` 文件中：
+
+```bash
+HUGEGRAPH_ADMIN_PASSWORD='replace-with-your-password'
+HUGEGRAPH_AUTH_TOKEN_SECRET='<32 字节随机值，例如 openssl rand -hex 32>'
+```
+
+`HUGEGRAPH_ADMIN_PASSWORD` 非空即开启 Server 鉴权，Hubble 通过 Server API 自动识别该模式。不设置或设为空值则关闭鉴权，这只适用于可信的本地环境。保持同一个 JWT 密钥可以在容器重建后继续使用已签发的 token，多 Server 拓扑中的每个副本都会收到同一个密钥。HA 拓扑设置了 `HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET: "true"`，因此只提供密码而没有共享密钥时会快速失败。请不要提交 `.env`。
+
+`HUGEGRAPH_ADMIN_PASSWORD` 只在第一次以鉴权模式启动时初始化内置的 `admin` 账号。之后修改它不会轮换已有密码，请使用用户 API 修改。
 
 ## 单节点快速启动
 
 ```bash
 cd hugegraph/docker
  # 注意版本号请随时保持更新 → 1.x.0 
-HUGEGRAPH_VERSION=1.7.0 docker compose up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose.yml up -d --wait
 ```
 
 验证：
 ```bash
 curl http://localhost:8080/versions
+curl http://localhost:8088/about        # Hubble
+```
+
+Hubble 默认只发布在宿主机回环地址（`127.0.0.1:8088`）。只有在 HTTPS 反向代理和可信网络管控之后才应设置 `HUBBLE_PUBLISH_HOST`。
+
+## 最小 HStore 快速启动
+
+```bash
+cd hugegraph/docker
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-hstore.yml up -d --wait
+```
+
+验证：
+```bash
+curl http://localhost:8620/v1/health    # PD
+curl http://localhost:8520/v1/health    # Store
+curl http://localhost:8080/versions     # Server
+curl http://localhost:8088/about        # Hubble
+```
+
+若要从本地源码构建该拓扑而不是拉取镜像，可加上开发覆盖文件，并在后续所有生命周期命令中同时带上这两个文件：
+
+```bash
+docker compose -f docker-compose-hstore.yml -f docker-compose.dev.yml up -d --build --wait
 ```
 
 ## 3 节点集群快速启动
 
 ```bash
 cd hugegraph/docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d --wait
 ```
 
 默认内置的启动顺序：
@@ -62,30 +102,43 @@ curl http://localhost:8620/v1/stores       # 已注册的 Store
 curl http://localhost:8620/v1/partitions   # 分区分配
 ```
 
+开启鉴权后，图列表接口应拒绝匿名请求并接受管理员：
+
+```bash
+curl -o /dev/null -w '%{http_code}\n' \
+  http://localhost:8080/graphspaces/DEFAULT/graphs                      # 期望 401
+curl -o /dev/null -w '%{http_code}\n' -u "admin:${HUGEGRAPH_ADMIN_PASSWORD}" \
+  http://localhost:8080/graphspaces/DEFAULT/graphs                      # 期望 200
+```
+
+另外两个 Server 分别在 `8081` 和 `8082` 上提供服务，其余 PD 和 Store 节点分别在 `8621`/`8622` 和 `8521`/`8522`。
+
 ## 环境变量参考
+
+PD 和 Store 的入口脚本会把各自的变量拼成 `SPRING_APPLICATION_JSON`，并在启动时打印生效值，因此 `docker logs` 中能看到容器实际解析出的配置。Server 的入口脚本则直接改写 `conf/graphs/hugegraph.properties` 和 `conf/rest-server.properties` 中的键。
 
 ### PD 变量
 
 | 变量 | 必填 | 默认值 | 映射配置 |
 |------|------|--------|----------|
-| `HG_PD_GRPC_HOST` | 是 | — | `grpc.host` |
-| `HG_PD_RAFT_ADDRESS` | 是 | — | `raft.address` |
-| `HG_PD_RAFT_PEERS_LIST` | 是 | — | `raft.peers-list` |
-| `HG_PD_INITIAL_STORE_LIST` | 是 | — | `pd.initial-store-list` |
+| `HG_PD_GRPC_HOST` | 是 | （无） | `grpc.host` |
+| `HG_PD_RAFT_ADDRESS` | 是 | （无） | `raft.address` |
+| `HG_PD_RAFT_PEERS_LIST` | 是 | （无） | `raft.peers-list` |
+| `HG_PD_INITIAL_STORE_LIST` | 是 | （无） | `pd.initial-store-list` |
 | `HG_PD_GRPC_PORT` | 否 | `8686` | `grpc.port` |
 | `HG_PD_REST_PORT` | 否 | `8620` | `server.port` |
 | `HG_PD_DATA_PATH` | 否 | `/hugegraph-pd/pd_data` | `pd.data-path` |
 | `HG_PD_INITIAL_STORE_COUNT` | 否 | `1` | `pd.initial-store-count` |
 
-> **已弃用的别名**：`GRPC_HOST` → `HG_PD_GRPC_HOST`、`RAFT_ADDRESS` → `HG_PD_RAFT_ADDRESS`、`RAFT_PEERS` → `HG_PD_RAFT_PEERS_LIST`
+> **已弃用的别名**：`GRPC_HOST` → `HG_PD_GRPC_HOST`、`RAFT_ADDRESS` → `HG_PD_RAFT_ADDRESS`、`RAFT_PEERS` → `HG_PD_RAFT_PEERS_LIST`、`PD_INITIAL_STORE_LIST` → `HG_PD_INITIAL_STORE_LIST`。只有当新名称未设置时才会把旧名称映射过去，并打印一条警告日志。任一必填变量缺失时，入口脚本以退出码 2 退出。
 
 ### Store 变量
 
 | 变量 | 必填 | 默认值 | 映射配置 |
 |------|------|--------|----------|
-| `HG_STORE_PD_ADDRESS` | 是 | — | `pdserver.address` |
-| `HG_STORE_GRPC_HOST` | 是 | — | `grpc.host` |
-| `HG_STORE_RAFT_ADDRESS` | 是 | — | `raft.address` |
+| `HG_STORE_PD_ADDRESS` | 是 | （无） | `pdserver.address` |
+| `HG_STORE_GRPC_HOST` | 是 | （无） | `grpc.host` |
+| `HG_STORE_RAFT_ADDRESS` | 是 | （无） | `raft.address` |
 | `HG_STORE_GRPC_PORT` | 否 | `8500` | `grpc.port` |
 | `HG_STORE_REST_PORT` | 否 | `8520` | `server.port` |
 | `HG_STORE_DATA_PATH` | 否 | `/hugegraph-store/storage` | `app.data-path` |
@@ -94,34 +147,76 @@ curl http://localhost:8620/v1/partitions   # 分区分配
 
 ### Server 变量
 
-| 变量 | 必填 | 默认值 | 映射配置 |
-|------|------|--------|----------|
-| `HG_SERVER_BACKEND` | 是 | — | `hugegraph.properties` 中的 `backend` |
-| `HG_SERVER_PD_PEERS` | 是 | — | `pd.peers` |
-| `STORE_REST` | 否 | — | `wait-partition.sh` 使用 |
-| `PASSWORD` | 否 | — | 启用鉴权模式 |
+与 PD、Store 不同，Server 入口脚本没有必填变量：只有实际设置了的变量才会被写入配置文件。但分布式部署至少需要 `HG_SERVER_BACKEND` 和 `HG_SERVER_PD_PEERS`。
+
+| 变量 | 默认值 | 映射配置 |
+|------|--------|----------|
+| `HG_SERVER_BACKEND` | 模板取值（`rocksdb`，在 `hugegraph/server` 镜像中为 `hstore`） | `conf/graphs/hugegraph.properties` 中的 `backend` |
+| `HG_SERVER_PD_PEERS` | （无） | `hugegraph.properties` 和 `rest-server.properties` 中的 `pd.peers` |
+| `HG_SERVER_USE_PD` | `false` | `rest-server.properties` 中的 `usePD` |
+| `HG_SERVER_CLUSTER` | `hg-test` | `rest-server.properties` 中的 `cluster` |
+| `HG_SERVER_REST_URL` | `http://0.0.0.0:8080`（镜像中已设置） | `restserver.url` |
+| `HG_SERVER_MIN_FREE_MEMORY` | `64`（MB） | `restserver.min_free_memory` |
+| `HG_SERVER_INIT_STORE_ENABLED` | `true` | `init_store.enabled`；元数据由存储侧管理的 PD/HStore 部署应设为 `false` |
+| `HG_SERVER_AUTH_TOKEN_SECRET` | 设置了 `PASSWORD` 时自动生成 | 两个配置文件中的 `auth.token_secret`，至少 32 字节 |
+| `HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET` | `false` | 为 `true` 时，只设置 `PASSWORD` 而未设置 `HG_SERVER_AUTH_TOKEN_SECRET` 则拒绝启动 |
+| `PASSWORD` | （无） | `auth.admin_pa`，并执行 `bin/enable-auth.sh` 开启鉴权模式 |
+| `PRELOAD` | （无） | 为 `true` 时从 `scripts/example.groovy` 预加载示例图 |
+| `JAVA_OPTS` | 镜像中已设置 | 传给 `bin/start-hugegraph.sh -j` |
+| `STORE_REST` | `store:8520` | `wait-partition.sh` 轮询的 Store REST 地址，仅 hstore 后端使用 |
+| `HG_SERVER_PD_REST_ENDPOINT` | 由 `pd.peers` 把 `:8686` 改写为 `:8620` 得到 | `wait-storage.sh` 轮询的 PD REST 地址 |
+| `PD_AUTH_USER` / `PD_AUTH_PASSWORD` | `store` / `admin` | `wait-storage.sh` 访问 PD REST API 使用的凭据 |
+| `WAIT_PARTITION_TIMEOUT_S` | `120` | `wait-partition.sh` 等待分区分配的时长 |
 
 > **已弃用的别名**：`BACKEND` → `HG_SERVER_BACKEND`、`PD_PEERS` → `HG_SERVER_PD_PEERS`
 
+`wait-storage.sh` 最多等待 300 秒直到出现状态为 `Up` 的 Store。该时长写死在脚本中，无法通过环境变量调整。
+
+`HG_SERVER_INIT_STORE_ENABLED` 只接受 `HugeConfig` 能识别的写法（忽略大小写）：`y`、`t`、`yes`、`on`、`true`、`n`、`f`、`no`、`off`、`false`。其他取值（包括 `0` 和 `1`）都会让入口脚本终止。
+
+入口脚本在初始化成功后写入 `docker/init_complete`，后续启动会跳过重新初始化，但仍会再执行一次 `bin/init-store.sh`，以便关闭状态下每次启动都重新校验配置。
+
+### Compose 变量
+
+以下变量由 Compose 文件读取，而非入口脚本：
+
+| 变量 | 默认值 | 用途 |
+|------|--------|------|
+| `HUGEGRAPH_VERSION` | `latest` | Server、PD 和 Store 的镜像 tag |
+| `HUGEGRAPH_PULL_POLICY` | `missing` | 上述镜像的 `pull_policy`，使用 `never` 可保留本地构建的镜像 |
+| `HUBBLE_IMAGE` | `hugegraph/hubble:latest` | Hubble 镜像，与 `HUGEGRAPH_VERSION` 独立选择 |
+| `HUBBLE_PULL_POLICY` | `missing` | Hubble 镜像的 `pull_policy` |
+| `HUBBLE_PUBLISH_HOST` | `127.0.0.1` | Hubble `8088` 端口发布到的宿主机网卡 |
+| `HUGEGRAPH_ADMIN_PASSWORD` | （无） | 以 `PASSWORD` 传给 Server |
+| `HUGEGRAPH_AUTH_TOKEN_SECRET` | （无） | 以 `HG_SERVER_AUTH_TOKEN_SECRET` 传给 Server |
+
 ## 端口参考
 
-| 服务 | 宿主机端口 | 用途 |
-|------|-----------|------|
-| pd0 | 8620 | REST API |
-| pd0 | 8686 | gRPC |
-| pd1 | 8621 | REST API |
-| pd1 | 8687 | gRPC |
-| pd2 | 8622 | REST API |
-| pd2 | 8688 | gRPC |
-| store0 | 8500 | gRPC |
-| store0 | 8520 | REST API |
-| store1 | 8501 | gRPC |
-| store1 | 8521 | REST API |
-| store2 | 8502 | gRPC |
-| store2 | 8522 | REST API |
-| server0 | 8080 | Graph API |
-| server1 | 8081 | Graph API |
-| server2 | 8082 | Graph API |
+3 节点集群发布的端口：
+
+| 服务 | 宿主机端口 | 容器端口 | 用途 |
+|------|-----------|----------|------|
+| pd0 | 8620 | 8620 | REST API |
+| pd0 | 8686 | 8686 | gRPC |
+| pd1 | 8621 | 8620 | REST API |
+| pd1 | 8687 | 8686 | gRPC |
+| pd2 | 8622 | 8620 | REST API |
+| pd2 | 8688 | 8686 | gRPC |
+| store0 | 8500 | 8500 | gRPC |
+| store0 | 8510 | 8510 | Raft |
+| store0 | 8520 | 8520 | REST API |
+| store1 | 8501 | 8500 | gRPC |
+| store1 | 8511 | 8510 | Raft |
+| store1 | 8521 | 8520 | REST API |
+| store2 | 8502 | 8500 | gRPC |
+| store2 | 8512 | 8510 | Raft |
+| store2 | 8522 | 8520 | REST API |
+| server0 | 8080 | 8080 | Graph API |
+| server1 | 8081 | 8080 | Graph API |
+| server2 | 8082 | 8080 | Graph API |
+| hubble | 8088 | 8088 | Hubble 界面，默认绑定 `127.0.0.1` |
+
+单机拓扑只发布 `8080` 和 `8088`；最小 HStore 拓扑发布 `8620`（PD REST）、`8520`（Store REST）、`8080` 和 `8088`。PD Raft 使用网络内的 `8610`，所有拓扑都不对外发布。
 
 ## 故障排查
 
@@ -129,11 +224,13 @@ curl http://localhost:8620/v1/partitions   # 分区分配
 
 2. **Raft 选举超时**：检查所有 PD 节点的 `HG_PD_RAFT_PEERS_LIST` 是否一致。验证连通性：`docker exec hg-pd0 ping pd1`
 
-3. **分区分配未完成**：检查 `curl http://localhost:8620/v1/stores` — 3 个 Store 必须都显示 `"state":"Up"` 才能完成分区分配
+3. **分区分配未完成**：检查 `curl http://localhost:8620/v1/stores`，3 个 Store 必须都显示 `"state":"Up"` 才能完成分区分配
 
 4. **连接被拒**：确保 `HG_*` 环境变量使用容器主机名（`pd0`、`store0`），而非 `127.0.0.1`
 
-**查看运行时日志**：使用 `docker logs <container-name>`（如 `docker logs hg-pd0`）可直接查看日志，无需进入容器。
+5. **数据在意料之外地保留了下来**：`docker compose down` 会保留命名卷。要同时删除该拓扑的数据，请使用 `docker compose down -v`
+
+**查看运行时日志**：使用 `docker logs <container-name>`（如 `docker logs hg-pd0`）可直接查看日志，无需进入容器。单机镜像 `hugegraph/hugegraph` 设置了 `STDOUT_MODE=true`，其服务日志会输出到容器 stdout。`hugegraph/server`（HStore）镜像没有设置该变量，因此对 HStore 拓扑的 Server 执行 `docker logs` 只能看到入口脚本的输出，其余内容需在容器内查看 `logs/hugegraph-server.log`。
 
 ## 容器监控与健康检查
 
@@ -145,7 +242,7 @@ curl http://localhost:8620/v1/partitions   # 分区分配
 
 现在，入口脚本直接监控 Java 进程：
 
-- **PD 和 Store 容器**：入口脚本向启动脚本传入 `-d false` 参数，启动脚本通过 `exec` 直接替换为 Java 进程。容器进程即为 Java 进程——当 Java 退出（崩溃或正常关闭）时，容器立即退出，Docker 的重启策略随即触发。
+- **PD 和 Store 容器**：入口脚本向启动脚本传入 `-d false` 参数，启动脚本通过 `exec` 直接替换为 Java 进程。容器进程即为 Java 进程，当 Java 退出（崩溃或正常关闭）时，容器立即退出，Docker 的重启策略随即触发。
 - **Server 容器**：入口脚本使用 `tail --pid=$PID -f /dev/null` 阻塞，直到 Java 退出。`SIGTERM`/`SIGINT` 信号陷阱会将 `docker stop` 信号转发给 Java 并等待其正常关闭（退出码 0）。若 Java 崩溃，入口脚本以退出码 1 退出，从而触发重启策略。
 - 所有镜像中的 PID 1 均为 `dumb-init`，负责将 Docker 信号转发给入口脚本进程。
 
@@ -155,9 +252,11 @@ curl http://localhost:8620/v1/partitions   # 分区分配
 
 | 镜像 | 健康检查端点 | 端口 | 参数 |
 |------|-------------|------|------|
-| `hugegraph/hugegraph`（server） | `GET /versions` | 8080 | `--interval=15s --timeout=10s --start-period=90s --retries=3` |
-| `hugegraph/hugegraph-hstore` | `GET /versions` | 8080 | 同上 |
-| `hugegraph/hugegraph-pd` | `GET /v1/health` | 8620 | 同上 |
-| `hugegraph/hugegraph-store` | `GET /v1/health` | 8520 | 同上 |
+| `hugegraph/hugegraph`（单机 RocksDB Server） | `GET /versions` | 8080 | `--interval=15s --timeout=10s --start-period=90s --retries=3` |
+| `hugegraph/server`（HStore Server） | `GET /versions` | 8080 | 同上 |
+| `hugegraph/pd` | `GET /v1/health` | 8620 | 同上 |
+| `hugegraph/store` | `GET /v1/health` | 8520 | 同上 |
+
+Compose 文件在此之上还定义了自己的健康检查，因此 `--wait` 和 `depends_on: condition: service_healthy` 不依赖镜像内置的检查。Compose 中的检查使用更短的启动期（视服务和拓扑为 30 到 120 秒）和更多的重试次数。
 
 > **注意**：`start-hugegraph.sh` 中的 `-m true` 标志（基于 cron 的监控）仅适用于虚拟机/裸机部署，Docker 镜像中未安装也不使用该功能。Docker 用户应依赖内置的 `HEALTHCHECK` 和 Docker 重启策略。

--- a/content/cn/docs/quickstart/hugegraph/hugegraph-server.md
+++ b/content/cn/docs/quickstart/hugegraph/hugegraph-server.md
@@ -14,7 +14,7 @@ aliases:
 
 > ⚠️ **版本说明**：本文以 HugeGraph 1.7.0 至 `master` 分支的代码为参考，仅介绍 RocksDB、HStore 和 HBase。其他旧后端的使用与配置请参考 [HugeGraph 1.5.x 文档](https://github.com/apache/hugegraph-doc/blob/release-1.5.0/content/cn/docs/quickstart/hugegraph/hugegraph-server.md)。
 
-> 名称说明：`HugeGraph` 表示整个项目或主仓库，`hugegraph-server` 表示仓库中的 Server 模块，`HugeGraphServer` 是服务进程的 Java 类名。下文使用“Server 服务”表示运行中的图数据库服务。
+> 名称说明：`HugeGraph` 表示整个项目或主仓库，`hugegraph-server` 表示仓库中的 Server 模块，`HugeGraphServer` 是服务进程的 Java 类名。下文的 Server 服务指运行中的图数据库服务。
 
 ## 2 依赖
 
@@ -24,7 +24,11 @@ HugeGraph 1.7.0 中的 `hugegraph-server` 模块使用 Java 11 编译，运行�
 
 **在继续阅读前，请先执行 `java -version` 命令确认 JDK 版本。**
 
-> 1.7.0 起不再支持 Java 8。
+> 1.7.0 起不再支持 Java 8。`bin/hugegraph-server.sh` 在低于 Java 11 的环境下会直接拒绝启动。
+
+> 安全检查默认开启，会安装 `HugeSecurityManager`，它要求 Java 11 到 23。JDK 24 移除了 Security Manager（[JEP 486](https://openjdk.org/jeps/486)），因此在 Java 24 及更高版本上必须关闭该检查后再启动服务：`bin/start-hugegraph.sh -s false`。
+
+> 源码构建还需要 Maven 3.5.0 或更高版本。
 
 ## 3 部署
 
@@ -59,18 +63,24 @@ HugeGraph 1.7.0 中的 `hugegraph-server` 模块使用 Java 11 编译，运行�
 > **注意**：Docker Compose 文件使用桥接网络（`hg-net`），适用于 Linux 和 Mac（Docker Desktop）。如需运行 3 节点分布式集群，请为 Docker Desktop 分配至少 **12 GB** 内存（设置 → 资源 → 内存）。Linux 上 Docker 直接使用宿主机内存。
 
 如果希望通过一个配置文件统一管理 HugeGraph 的多个服务实例，则可以使用 `docker compose`。
-[`docker/`](https://github.com/apache/hugegraph/tree/master/docker) 目录下提供了两个 compose 文件：
+[`docker/`](https://github.com/apache/hugegraph/tree/master/docker) 目录下提供了四个 compose 文件：
 
-- **单节点快速启动**（预构建镜像）：`docker/docker-compose.yml`
-- **单节点开发构建**（从源码构建）：`docker/docker-compose.dev.yml`
+| 拓扑 | compose 文件 | 服务 |
+|---|---|---|
+| 单机（推荐从这里开始） | `docker-compose.yml` | 1 个 RocksDB Server + 1 个 Hubble |
+| 最小 HStore | `docker-compose-hstore.yml` | 1 PD + 1 Store + 1 Server + 1 Hubble |
+| HA 参考 | `docker-compose-3pd-3store-3server.yml` | 3 PD + 3 Store + 3 Server + 1 Hubble |
+| 最小 HStore 拓扑的源码构建覆盖文件 | `docker-compose.dev.yml` | （需与 `docker-compose-hstore.yml` 一起使用） |
 
 ```bash
 cd hugegraph/docker
 # 注意版本号请随时保持更新 → 1.x.0
-HUGEGRAPH_VERSION=1.7.0 docker compose up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose.yml up -d --wait
 ```
 
-如需开启鉴权，可在 compose 文件的环境变量中添加 `PASSWORD=xxx`，或在 `docker run` 命令中传入 `-e PASSWORD=xxx`。
+单机拓扑将 Server 暴露在 `8080` 端口，Hubble 暴露在 `127.0.0.1:8088`。`HUGEGRAPH_VERSION` 决定 Server、PD 和 Store 的镜像 tag，Hubble 由 `HUBBLE_IMAGE` 单独选择。
+
+compose 文件从 `HUGEGRAPH_ADMIN_PASSWORD` 读取管理员密码，从 `HUGEGRAPH_AUTH_TOKEN_SECRET` 读取 JWT 密钥，通常放在 `docker/.env` 文件中。`HUGEGRAPH_ADMIN_PASSWORD` 非空即开启鉴权，Hubble 会自动识别该模式。若直接使用 `docker run`，则改为传入 `-e PASSWORD=xxx`。
 
 完整的部署指南请参阅 [docker/README.md](https://github.com/apache/hugegraph/blob/master/docker/README.md)。
 
@@ -114,6 +124,12 @@ mvn package -DskipTests
 
 执行成功后，在 hugegraph 目录下生成 `*hugegraph-*.tar.gz` 文件，就是编译生成的 tar 包。
 
+默认构建会打包 `rocksdb`、`hbase` 和 `hstore` 三个后端模块，并把它们记录在 `hugegraph-dist` jar 内的 `backend.properties` 资源的 `backends` 配置项中。若只需要包含 RocksDB 的精简发布包，可加上 `-Drocksdb-only`：
+
+```bash
+mvn package -DskipTests -ntp -Drocksdb-only
+```
+
 > [!DETAILS]- 过时的 tools 工具安装
 > #### 3.4 使用 tools 工具部署 (Outdated)
 >
@@ -147,7 +163,7 @@ mvn package -DskipTests
 
 ### 5.1 使用启动脚本启动
 
-启动流程分为“首次启动”和“非首次启动”。首次启动前需要先初始化后端数据库，然后再启动服务。
+启动流程分为首次启动和非首次启动两种情况。首次启动前需要先初始化后端数据库，然后再启动服务。
 
 如果服务曾被手动停止，或因其他原因需要再次启动，由于后端数据库已持久化存在，通常可以直接启动服务。
 
@@ -175,7 +191,6 @@ HugeGraphServer 启动时会连接后端存储并检查其版本信息。如果�
 ```properties
 backend=hstore
 serializer=binary
-task.scheduler_type=distributed
 
 # PD 服务地址，多个 PD 地址用逗号分割，配置 PD 的 RPC 端口
 pd.peers=127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688
@@ -190,12 +205,13 @@ backend=hstore
 serializer=binary
 store=hugegraph
 
-# 指定任务调度器（1.7.0及之前，hstore 存储必须）
-task.scheduler_type=distributed
-
 # pd config
 pd.peers=127.0.0.1:8686
 ```
+
+发布包中自带该后端的模板文件 `conf/graphs/hstore.properties.template`，可将其复制覆盖 `conf/graphs/hugegraph.properties` 后修改 `pd.peers`。
+
+任务调度器由后端决定，无需配置 `task.scheduler_type`：`hstore` 使用分布式调度器，其余后端使用本地调度器。为兼容旧配置，该键仍可存在，但会被忽略并打印一条警告日志。
 
 2. 修改 Server 服务的 `rest-server.properties` 配置：
 
@@ -265,7 +281,7 @@ bin/start-hugegraph.sh
 2. 启动 HugeGraph-Store
 3. 启动 Server 服务
 
-HStore 的元数据和存储由 PD、Store 管理，`init-store` 会跳过该后端，不需要单独执行初始化脚本。
+HStore 的元数据和存储由 PD、Store 管理，`init-store` 会跳过该后端。开启鉴权时，执行 `init-store` 仍会创建内置的 `admin` 账号。如果该账号已由存储侧持有，可在 `rest-server.properties` 中设置 `init_store.enabled=false` 以整体跳过这一步，Docker 的 HStore 拓扑即采用这种方式。
 
 验证服务是否正常启动：
 
@@ -290,16 +306,26 @@ bin/stop-hugegraph.sh
 
 ```bash
 cd hugegraph/docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d --wait
 ```
 
 服务通过 `hg-net` 桥接网络上的容器主机名进行通信。配置通过环境变量注入：
 
 ```yaml
-# Server 配置
+# Server 配置，server0、server1、server2 共用
 HG_SERVER_BACKEND: hstore
 HG_SERVER_PD_PEERS: pd0:8686,pd1:8686,pd2:8686
+HG_SERVER_CLUSTER: hg
+HG_SERVER_USE_PD: "true"
+HG_SERVER_MIN_FREE_MEMORY: "0"
+HG_SERVER_INIT_STORE_ENABLED: "false"
+HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET: "true"
+STORE_REST: store0:8520
+# 每个节点单独设置，例如 server0
+HG_SERVER_REST_URL: http://server0:8080
 ```
+
+该拓扑设置了 `HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET: "true"`，因此在只提供密码而没有共享 JWT 密钥时 Server 会拒绝启动。启动前请在 `docker/.env` 中同时写入 `HUGEGRAPH_ADMIN_PASSWORD` 和 `HUGEGRAPH_AUTH_TOKEN_SECRET`。完整的变量说明见 [Docker 集群指南](/cn/docs/guides/hugegraph-docker-cluster/)。
 
 验证集群：
 ```bash
@@ -348,8 +374,9 @@ bin/init-store.sh
 
 ```bash
 bin/start-hugegraph.sh
-Starting HugeGraphServer...
+Starting HugeGraphServer in daemon mode...
 Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)....OK
+Started [pid 21614]
 ```
 
 提示的 url 与 `rest-server.properties` 中配置的 `restserver.url` 一致
@@ -392,8 +419,9 @@ bin/init-store.sh
 
 ```bash
 bin/start-hugegraph.sh
-Starting HugeGraphServer...
+Starting HugeGraphServer in daemon mode...
 Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)....OK
+Started [pid 21614]
 ```
 
 > 更多其它后端配置可参考[配置项介绍](/docs/config/config-option)
@@ -419,6 +447,23 @@ Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)......OK
 ```
 
 代表创建示例图成功。
+
+#### 5.1.5 启动脚本的参数
+
+`bin/start-hugegraph.sh` 支持以下参数。每个参数都需要带值，即写作 `-d false`，不能只写 `-d`。
+
+| 参数 | 取值 | 默认值 | 作用 |
+|---|---|---|---|
+| `-d` | `true`、`false` | `true` | 守护进程模式。`-d false` 时脚本留在前台，并把 `SIGTERM`/`SIGINT` 转发给服务进程 |
+| `-g` | `zgc` 或 `ZGC` | 不填则用 G1GC | 选择垃圾回收器。只接受 ZGC，其他取值会直接终止启动；ZGC 需要 Java 11 及以上 |
+| `-m` | `true`、`false` | `false` | 安装基于 crontab 的监控任务（`bin/start-monitor.sh`），仅用于虚拟机和物理机部署 |
+| `-p` | `true`、`false` | `false` | 预加载示例图，见 5.1.4 |
+| `-s` | `true`、`false` | `true` | 开启安全检查（`HugeSecurityManager`）。要求 Java 11 到 23，且 `conf/java-security.properties` 可读 |
+| `-j` | JVM 参数 | 空 | 追加到服务命令行的额外 JVM 参数 |
+| `-t` | 秒 | `30` | 判定启动失败前等待服务响应的时长 |
+| `-y` | `true`、`false` | `false` | 开启 OpenTelemetry agent 上报链路追踪 |
+
+`bin/stop-hugegraph.sh` 支持 `-m true|false`（默认 `true`），用于控制停止服务时是否同时移除 crontab 监控任务。
 
 ### 5.2 使用 Docker
 
@@ -446,12 +491,12 @@ Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)......OK
           - PRELOAD=true
           - PASSWORD=xxx
         volumes:
-          - /path/to/yourscript:/hugegraph/scripts/example.groovy
+          - /path/to/yourscript:/hugegraph-server/scripts/example.groovy
         ports:
           - 8080:8080
     ```
 
-    使用命令 `docker-compose up -d` 启动容器
+    使用命令 `docker compose up -d` 启动容器
 
 使用 RESTful API 请求 `HugeGraphServer` 得到如下结果：
 

--- a/content/en/docs/clients/gremlin-console.md
+++ b/content/en/docs/clients/gremlin-console.md
@@ -109,41 +109,33 @@ serializer: {
 }
 ```
 
+If the Server runs in auth mode, add the credentials to the same file:
+
+```yaml
+username: admin
+password: pa
+```
+
+The `conf` directory also ships `remote-objects.yaml` and `gremlin-driver-settings.yaml`, which carry the same host, port, and serializer settings.
+
 ```groovy
 gremlin> :remote connect tinkerpop.server conf/remote.yaml
 ==>Configured localhost/127.0.0.1:8182
 ```
 
-After a successful connection, if the sample graph `example.groovy` is imported during the startup of HugeGraph-Server, you can directly perform queries in the console.
+Server-side graphs are bound under a graphspace-qualified name, so the graph `hugegraph` in graphspace `DEFAULT` is bound as `DEFAULT-hugegraph` and its traversal source as `__g_DEFAULT-hugegraph`. A bare `hugegraph` does not resolve on the Server, and `DEFAULT-hugegraph` is not a valid Groovy identifier, so a remote script reaches the traversal source through an alias. If the sample graph was preloaded when HugeGraph-Server started, a query looks like this:
 
 ```groovy
-gremlin> :> hugegraph.traversal().V()
-==>[id:2:lop,label:software,type:vertex,properties:[name:lop,lang:java,price:328]]
-==>[id:1:josh,label:person,type:vertex,properties:[name:josh,age:32,city:Beijing]]
-==>[id:1:marko,label:person,type:vertex,properties:[name:marko,age:29,city:Beijing]]
-==>[id:1:peter,label:person,type:vertex,properties:[name:peter,age:35,city:Shanghai]]
-==>[id:1:vadas,label:person,type:vertex,properties:[name:vadas,age:27,city:Hongkong]]
-==>[id:2:ripple,label:software,type:vertex,properties:[name:ripple,lang:java,price:199]]
-```
-
-> NOTE: In Client/Server mode, all operations related to the Server should be prefixed with `:> `. If not added, it indicates local console operations.
-
-You can also put multiple statements in a single string variable and send them to the Server at once:
-
-```groovy
-gremlin> script = """
-......1> graph = hugegraph;
-......2> g = graph.traversal();
-......3> g.V().toList().size();
-......4> """
-==>
-graph = hugegraph;
-g = graph.traversal();
-g.V().toList().size();
-
-gremlin> :> @script
+gremlin> import org.apache.tinkerpop.gremlin.driver.Cluster
+gremlin> cluster = Cluster.open('conf/remote.yaml')
+gremlin> client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
+gremlin> client.submit('g.V().count()').all().get()[0].object
 ==>6
-gremlin> 
+gremlin> client.submit('g.V().toList().size()').all().get()[0].object
+==>6
+gremlin> client.close(); cluster.close()
 ```
+
+> NOTE: In Client/Server mode, all operations related to the Server should be prefixed with `:> `. If not added, it indicates local console operations. A `:> ` script carries no alias, so it can only use names the Server itself has bound.
 
 For more information on the use of Gremlin-Console, please refer to [Tinkerpop Official Website](http://tinkerpop.apache.org/docs/current/reference/)

--- a/content/en/docs/config/config-guide.md
+++ b/content/en/docs/config/config-guide.md
@@ -48,6 +48,8 @@ scriptEngines: {
           org.apache.hugegraph.backend.id.IdGenerator,
           org.apache.hugegraph.type.define.Directions,
           org.apache.hugegraph.type.define.NodeRole,
+          org.apache.hugegraph.masterelection.GlobalMasterInfo,
+          org.apache.hugegraph.util.DateUtil,
           org.apache.hugegraph.traversal.algorithm.CollectionPathsTraverser,
           org.apache.hugegraph.traversal.algorithm.CountTraverser,
           org.apache.hugegraph.traversal.algorithm.CustomizedCrosspointsTraverser,
@@ -72,7 +74,6 @@ scriptEngines: {
           org.apache.hugegraph.traversal.optimize.ConditionP,
           org.apache.hugegraph.traversal.optimize.Text,
           org.apache.hugegraph.traversal.optimize.TraversalUtil,
-          org.apache.hugegraph.util.DateUtil,
           org.opencypher.gremlin.traversal.CustomFunctions,
           org.opencypher.gremlin.traversal.CustomPredicate
         ],
@@ -138,9 +139,9 @@ In most cases, you only need to pay attention to `channelizer`, `host`, and `por
 
 - `channelizer`: The default `WsAndHttpChannelizer` supports both WebSocket and HTTP. Gremlin Console uses WebSocket, while HugeGraph Client, Loader, and Hubble use HTTP.
 
-By default, the GremlinServer serves at `localhost:8182`. If you need to modify it, configure the `host` and `port` settings.
+By default, the GremlinServer serves at `127.0.0.1:8182`. If you need to modify it, configure the `host` and `port` settings.
 
-- `host`: The hostname or IP address of the machine where the GremlinServer is deployed. Currently, HugeGraphServer does not support distributed deployment, and GremlinServer is not directly exposed to users.
+- `host`: The hostname or IP address of the machine where the GremlinServer is deployed. GremlinServer is not directly exposed to users, the RestServer forwards Gremlin requests to it.
 - `port`: The port number of the machine where the GremlinServer is deployed.
 
 Additionally, you need to add the corresponding configuration `gremlinserver.url=http://host:port` in `rest-server.properties`.
@@ -155,7 +156,7 @@ The following is an example of the available `rest-server.properties` options. T
 restserver.url=http://127.0.0.1:8080
 #restserver.enable_graphspaces_filter=false
 # gremlin server url, need to be consistent with host and port in gremlin-server.yaml
-#gremlinserver.url=http://127.0.0.1:8182
+#gremlinserver.url=127.0.0.1:8182
 
 graphs=./conf/graphs
 graph.load_from_local_config=true
@@ -195,32 +196,40 @@ memory_monitor.period=2000
 
 > The current upstream template still uses `arthas.telnet_port`, `arthas.http_port`, and `arthas.disabled_commands`, but `ServerOptions` reads the camelCase names shown in the example above. Custom configurations should use `arthas.telnetPort`, `arthas.httpPort`, and `arthas.disabledCommands`.
 
-> The `gremlinserver.url` configuration option is the URL at which the GremlinServer provides services to the RestServer. By default, it is set to `http://localhost:8182`. If you need to modify it, it should match the `host` and `port` settings in `gremlin-server.yaml`.
+> The `gremlinserver.url` configuration option is the URL at which the GremlinServer provides services to the RestServer. By default, it is set to `http://127.0.0.1:8182`. If you need to modify it, it should match the `host` and `port` settings in `gremlin-server.yaml`. The value may omit the scheme, as the template does, because `http://` is prepended when it is missing.
 
 ### 4. hugegraph.properties
 
 `hugegraph.properties` is a type of file. If the system has multiple graphs, there will be multiple similar files. This file is used to configure parameters related to graph storage and querying. The default content of the file is as follows:
 
 ```properties
-# gremlin entrence to create graph
+# gremlin entrance to create graph
+# auth config: org.apache.hugegraph.auth.HugeFactoryAuthProxy
 gremlin.graph=org.apache.hugegraph.HugeFactory
 
 # cache config
 #schema.cache_capacity=100000
 # vertex-cache default is 1000w, 10min expired
+vertex.cache_type=l2
 #vertex.cache_capacity=10000000
 #vertex.cache_expire=600
 # edge-cache default is 100w, 10min expired
+edge.cache_type=l2
 #edge.cache_capacity=1000000
 #edge.cache_expire=600
 
+
 # schema illegal name template
 #schema.illegal_name_regex=\s+|~.*
+
+#vertex.default_label=vertex
 
 # NOTE: since 1.7.0, only hstore, rocksdb, hbase, memory are supported for backend.
 # if you want to use Cassandra/MySql/PG... as backend, please use version < 1.7.0
 backend=rocksdb
 serializer=binary
+# The process-wide max capacity of one serialization buffer in bytes
+#serializer.buffer_max_capacity=134217728
 
 store=hugegraph
 
@@ -232,7 +241,7 @@ task.schedule_period=10
 task.retry=0
 task.wait_timeout=10
 
-# if use 'ikanalyzer', need download jar from 'https://github.com/apache/hugegraph-doc/raw/ik_binary/dist/server/ikanalyzer-2012_u6.jar' to lib directory
+# search config
 search.text_analyzer=jieba
 search.text_analyzer_mode=INDEX
 
@@ -245,16 +254,34 @@ search.text_analyzer_mode=INDEX
 #hbase.port=2181
 #hbase.znode_parent=/hbase
 #hbase.threads_max=64
+# IMPORTANT: recommend to modify the HBase partition number
+#            by the actual/env data amount & RS amount before init store
+#            It will influence the load speed a lot
+#hbase.enable_partition=true
+#hbase.vertex_partitions=10
+#hbase.edge_partitions=30
+
+# WARNING: These raft configurations are deprecated, please use the latest version instead.
+# raft.mode=false
+
+# memory management config
+#memory.mode=off-heap
+#memory.max_capacity=1073741824
+#memory.one_query_max_capacity=104857600
+#memory.alignment=8
 ```
 
 Pay attention to the following uncommented items:
 
-- `gremlin.graph`: The entry point for GremlinServer startup. Users should not modify this item.
+- `gremlin.graph`: The entry point for GremlinServer startup. Users should not modify this item, except to switch it to `org.apache.hugegraph.auth.HugeFactoryAuthProxy` when authentication is enabled.
+- `vertex.cache_type` / `edge.cache_type`: The cache implementation, allowed values are `l1` and `l2`. The default is `l2`.
 - `backend`: The storage backend. Version 1.7.0 supports `memory`, `rocksdb`, `hstore`, and `hbase`.
 - `serializer`: The serializer used when writing schemas, vertices, and edges to the backend. RocksDB uses `binary`.
 - `store`: The storage name used by the graph in the backend.
-- `rocksdb.data_path`: This item is only meaningful when the backend is set to `rocksdb`. It specifies the data directory for RocksDB.
-- `rocksdb.wal_path`: This item is only meaningful when the backend is set to `rocksdb`. It specifies the log directory for RocksDB.
+- `task.schedule_period`, `task.retry`, `task.wait_timeout`: Scheduling period (in seconds), retry count, and wait timeout (in seconds) for asynchronous tasks. The scheduler itself is picked from the backend, `hstore` uses the distributed scheduler and every other backend uses the local one. The old `task.scheduler_type` key is ignored.
+- `search.text_analyzer` / `search.text_analyzer_mode`: The analyzer used for full-text indexes and its mode. Available analyzers are `ansj`, `hanlp`, `smartcn`, `jieba`, `jcseg`, `mmseg4j`, and `ikanalyzer`, and each one accepts its own set of modes.
+- `rocksdb.data_path`: This item is only meaningful when the backend is set to `rocksdb`. It specifies the data directory for RocksDB, and defaults to `rocksdb-data/data`.
+- `rocksdb.wal_path`: This item is only meaningful when the backend is set to `rocksdb`. It specifies the log directory for RocksDB, and defaults to `rocksdb-data/wal`.
 
 ### 5. Multi-Graph Configuration
 
@@ -315,8 +342,8 @@ Initialization finished.
 ```bash
 $ ./bin/start-hugegraph.sh
 
-Starting HugeGraphServer...
-Connecting to HugeGraphServer (http://127.0.0.1:8080/graphspaces/DEFAULT/graphs)...OK
+Starting HugeGraphServer in daemon mode...
+Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)...OK
 Started [pid 21614]
 ```
 

--- a/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
+++ b/content/en/docs/contribution-guidelines/hugegraph-server-idea-setup.md
@@ -30,12 +30,14 @@ git clone https://github.com/apache/hugegraph.git
 To avoid the impact of configuration file changes on Git tracking, it is recommended to copy the required configuration files to a separate folder. Run the following command to copy the files:
 
 ```bash
-cp -r hugegraph-dist/src/assembly/static/scripts hugegraph-dist/src/assembly/static/conf path-to-your-directory
+cp -r hugegraph-server/hugegraph-dist/src/assembly/static/scripts \
+      hugegraph-server/hugegraph-dist/src/assembly/static/conf \
+      path-to-your-directory
 ```
 
-Replace `path-to-your-directory` with the path to the directory where you want to copy the files.
+Replace `path-to-your-directory` with the path to the directory where you want to copy the files. Run the command from the repository root, the `hugegraph-dist` module lives under the top-level `hugegraph-server` directory.
 
-> After introducing ToplingDB, developers need to execute the `preload-topling.sh` script, which automatically extracts the required dynamic libraries and Web Server static resources into the `library` directory located alongside the `bin` directory (the static resources will also be copied to `/dev/shm/rocksdb_resource` ).
+> ToplingDB is not part of the `master` distribution. In a build that includes it, developers need to execute the `preload-topling.sh` script, which automatically extracts the required dynamic libraries and Web Server static resources into the `library` directory located alongside the `bin` directory (the static resources will also be copied to `/dev/shm/rocksdb_resource` ).
 
 #### 2. Configure `InitStore` to initialize the graph
 
@@ -53,11 +55,11 @@ Next, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create a ne
 - Select `hugegraph-dist` as the `Use classpath of module`.
 - Set the `Main class` to `org.apache.hugegraph.cmd.InitStore`.
 - Set the program arguments to `conf/rest-server.properties`. Note that the path here is relative to the working directory, so make sure to set the working directory to `path-to-your-directory`.
-- ToplingDB requires preloading dynamic libraries via the `LD_PRELOAD` mechanism. Developers need to set two environment variables: `LD_LIBRARY_PATH` should point to the `library` directory extracted by `preload-topling.sh`, and `LD_PRELOAD` should be set to `libjemalloc.so:librocksdbjni-linux64.so` to ensure the necessary libraries are correctly loaded at runtime.
+- (Optional, ToplingDB builds only) ToplingDB requires preloading dynamic libraries via the `LD_PRELOAD` mechanism. Developers need to set two environment variables: `LD_LIBRARY_PATH` should point to the `library` directory extracted by `preload-topling.sh`, and `LD_PRELOAD` should be set to `libjemalloc.so:librocksdbjni-linux64.so` to ensure the necessary libraries are correctly loaded at runtime.
   - LD_LIBRARY_PATH=/path/to/your/library:$LD_LIBRARY_PATH
   - LD_PRELOAD=libjemalloc.so:librocksdbjni-linux64.so
 
-> If **user authentication** (authenticator) is configured for HugeGraph-Server in the **Java 11** environment, you need to refer to the script [configuration](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/init-store.sh#L52) in the binary package and add the following **VM options**:
+> If **user authentication** (authenticator) is configured for HugeGraph-Server in the **Java 11** environment, you need to refer to the script [configuration](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/init-store.sh#L49) in the binary package and add the following **VM options**:
 >
 > ```bash
 > --add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED
@@ -93,7 +95,9 @@ Similarly, open the `Run/Debug Configurations` panel in IntelliJ IDEA and create
 - Set the `Main class` to `org.apache.hugegraph.dist.HugeGraphServer`.
 - Set the program arguments to `conf/gremlin-server.yaml conf/rest-server.properties`. Similarly, note that the path here is relative to the working directory, so make sure to set the working directory to `path-to-your-directory`.
 
-> Similarly, if **user authentication** (authenticator) is configured for HugeGraph-Server in the **Java 11** environment, you need to refer to the script [configuration](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh#L124) in the binary package and add the following **VM options**:
+> `bin/hugegraph-server.sh` in the binary package does not start this class directly. It starts `org.apache.hugegraph.bootstrap.HugeGraphServerBootstrap`, which takes a leading `true`/`false` security-check flag before the two configuration paths, installs `HugeSecurityManager` when that flag is `true`, and then hands over to `HugeGraphServer`. Running `HugeGraphServer` from IDEA skips that wrapper, so the security manager is not installed, which is normally what you want while debugging.
+
+> Similarly, if **user authentication** (authenticator) is configured for HugeGraph-Server in the **Java 11** environment, you need to refer to the script [configuration](https://github.com/apache/hugegraph/blob/master/hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh#L132) in the binary package and add the following **VM options**:
 >
 > ```bash
 > --add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED --add-modules=jdk.unsupported --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
@@ -134,7 +138,7 @@ At this point, you can view detailed variable information in the debugger.
 
 #### 5. Log4j2 Configuration
 
-By default, when running `InitStore` and `HugeGraphServer`, the Log4j2 configuration file path read is `hugegraph-dist/src/main/resources/log4j2.xml`, not `path-to-your-directory/conf/log4j2.xml`. This configuration file is read when starting HugeGraph-Server using the **script**.
+By default, when running `InitStore` and `HugeGraphServer`, the Log4j2 configuration file path read is `hugegraph-server/hugegraph-dist/src/main/resources/log4j2.xml`, not `path-to-your-directory/conf/log4j2.xml`. This configuration file is read when starting HugeGraph-Server using the **script**.
 
 To avoid maintaining two separate configuration files, you can modify the Log4j2 configuration file path when running and debugging HugeGraph-Server in **IntelliJ IDEA**:
 

--- a/content/en/docs/guides/hugegraph-docker-cluster.md
+++ b/content/en/docs/guides/hugegraph-docker-cluster.md
@@ -18,34 +18,74 @@ HugeGraph can quickly run a full distributed deployment (PD + Store + Server) wi
 
 ## Compose Files
 
-Three compose files are available in the [`docker/`](https://github.com/apache/hugegraph/tree/master/docker) directory of the HugeGraph main repository:
+Four compose files are available in the [`docker/`](https://github.com/apache/hugegraph/tree/master/docker) directory of the HugeGraph main repository:
 
-| File | Description |
-|------|-------------|
-| `docker-compose.yml` | Quickstart for a single-host deployment using pre-built images |
-| `docker-compose.dev.yml` | Development mode for a single-host deployment built from source |
-| `docker-compose-3pd-3store-3server.yml` | Distributed cluster with 3 PD, 3 Store, and 3 Server processes |
+| File | Services | When to use it |
+|------|----------|----------------|
+| `docker-compose.yml` | 1 RocksDB Server + 1 Hubble | Default standalone quickstart, start here |
+| `docker-compose-hstore.yml` | 1 PD + 1 Store + 1 Server + 1 Hubble | Distributed local development |
+| `docker-compose-3pd-3store-3server.yml` | 3 PD + 3 Store + 3 Server + 1 Hubble | HA reference and evaluation |
+| `docker-compose.dev.yml` | (override only) | Source build overlay for the minimal HStore topology, always used together with `docker-compose-hstore.yml` |
+
+The standalone topology uses `hugegraph/hugegraph:${HUGEGRAPH_VERSION:-latest}`. The HStore topologies use the matching `hugegraph/pd`, `hugegraph/store`, and `hugegraph/server` tags. Hubble is selected independently with `${HUBBLE_IMAGE:-hugegraph/hubble:latest}`.
 
 > **Note**: The following steps assume you have already cloned or pulled the HugeGraph main repository locally, or at least have its `docker/` directory available.
+
+## Authentication Environment
+
+All topologies read the administrator password and the shared JWT secret from the Compose environment, normally a `docker/.env` file:
+
+```bash
+HUGEGRAPH_ADMIN_PASSWORD='replace-with-your-password'
+HUGEGRAPH_AUTH_TOKEN_SECRET='<32 random bytes, for example openssl rand -hex 32>'
+```
+
+A non-empty `HUGEGRAPH_ADMIN_PASSWORD` enables Server authentication, and Hubble detects that mode through the Server API. Omitting it, or setting it to an empty value, disables authentication, which is only suitable for a trusted local environment. Keeping the same JWT secret preserves tokens when containers are recreated, and every Server replica in a multi-Server topology receives the same secret. The HA topology sets `HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET: "true"`, so it fails fast when a password is supplied without the shared secret. Do not commit `.env`.
+
+`HUGEGRAPH_ADMIN_PASSWORD` initializes the built-in `admin` account on the first authenticated startup. Changing it later does not rotate an existing password, use the user API for that.
 
 ## Single-Node Quickstart
 
 ```bash
 cd hugegraph/docker
 # Keep the version aligned with the latest release, for example 1.x.0
-HUGEGRAPH_VERSION=1.7.0 docker compose up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose.yml up -d --wait
 ```
 
 Verify:
 ```bash
 curl http://localhost:8080/versions
+curl http://localhost:8088/about        # Hubble
+```
+
+Hubble is published on host loopback (`127.0.0.1:8088`) by default. Set `HUBBLE_PUBLISH_HOST` only behind an HTTPS reverse proxy and trusted network controls.
+
+## Minimal HStore Quickstart
+
+```bash
+cd hugegraph/docker
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-hstore.yml up -d --wait
+```
+
+Verify:
+```bash
+curl http://localhost:8620/v1/health    # PD
+curl http://localhost:8520/v1/health    # Store
+curl http://localhost:8080/versions     # Server
+curl http://localhost:8088/about        # Hubble
+```
+
+To build this topology from local source instead of pulling images, add the development overlay and keep both files on every later lifecycle command:
+
+```bash
+docker compose -f docker-compose-hstore.yml -f docker-compose.dev.yml up -d --build --wait
 ```
 
 ## 3-Node Cluster Quickstart
 
 ```bash
 cd hugegraph/docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d --wait
 ```
 
 Built-in startup ordering:
@@ -62,30 +102,43 @@ curl http://localhost:8620/v1/stores       # Registered stores
 curl http://localhost:8620/v1/partitions   # Partition assignment
 ```
 
+With authentication on, a graph listing must reject an anonymous request and accept the administrator:
+
+```bash
+curl -o /dev/null -w '%{http_code}\n' \
+  http://localhost:8080/graphspaces/DEFAULT/graphs                      # expect 401
+curl -o /dev/null -w '%{http_code}\n' -u "admin:${HUGEGRAPH_ADMIN_PASSWORD}" \
+  http://localhost:8080/graphspaces/DEFAULT/graphs                      # expect 200
+```
+
+The other two Servers answer on `8081` and `8082`, and the other PD and Store nodes on `8621`/`8622` and `8521`/`8522`.
+
 ## Environment Variable Reference
+
+The PD and Store entrypoints turn their variables into a `SPRING_APPLICATION_JSON` document and log the effective values at startup, so `docker logs` shows exactly what a container resolved. The Server entrypoint instead rewrites keys in `conf/graphs/hugegraph.properties` and `conf/rest-server.properties`.
 
 ### PD Variables
 
 | Variable | Required | Default | Maps To |
 |----------|----------|---------|---------|
-| `HG_PD_GRPC_HOST` | Yes | — | `grpc.host` |
-| `HG_PD_RAFT_ADDRESS` | Yes | — | `raft.address` |
-| `HG_PD_RAFT_PEERS_LIST` | Yes | — | `raft.peers-list` |
-| `HG_PD_INITIAL_STORE_LIST` | Yes | — | `pd.initial-store-list` |
+| `HG_PD_GRPC_HOST` | Yes | (none) | `grpc.host` |
+| `HG_PD_RAFT_ADDRESS` | Yes | (none) | `raft.address` |
+| `HG_PD_RAFT_PEERS_LIST` | Yes | (none) | `raft.peers-list` |
+| `HG_PD_INITIAL_STORE_LIST` | Yes | (none) | `pd.initial-store-list` |
 | `HG_PD_GRPC_PORT` | No | `8686` | `grpc.port` |
 | `HG_PD_REST_PORT` | No | `8620` | `server.port` |
 | `HG_PD_DATA_PATH` | No | `/hugegraph-pd/pd_data` | `pd.data-path` |
 | `HG_PD_INITIAL_STORE_COUNT` | No | `1` | `pd.initial-store-count` |
 
-> **Deprecated aliases**: `GRPC_HOST` → `HG_PD_GRPC_HOST`, `RAFT_ADDRESS` → `HG_PD_RAFT_ADDRESS`, `RAFT_PEERS` → `HG_PD_RAFT_PEERS_LIST`
+> **Deprecated aliases**: `GRPC_HOST` → `HG_PD_GRPC_HOST`, `RAFT_ADDRESS` → `HG_PD_RAFT_ADDRESS`, `RAFT_PEERS` → `HG_PD_RAFT_PEERS_LIST`, `PD_INITIAL_STORE_LIST` → `HG_PD_INITIAL_STORE_LIST`. A deprecated name is mapped to the new one only when the new one is unset, and the entrypoint logs a warning. The entrypoint exits with code 2 when any required variable is missing.
 
 ### Store Variables
 
 | Variable | Required | Default | Maps To |
 |----------|----------|---------|---------|
-| `HG_STORE_PD_ADDRESS` | Yes | — | `pdserver.address` |
-| `HG_STORE_GRPC_HOST` | Yes | — | `grpc.host` |
-| `HG_STORE_RAFT_ADDRESS` | Yes | — | `raft.address` |
+| `HG_STORE_PD_ADDRESS` | Yes | (none) | `pdserver.address` |
+| `HG_STORE_GRPC_HOST` | Yes | (none) | `grpc.host` |
+| `HG_STORE_RAFT_ADDRESS` | Yes | (none) | `raft.address` |
 | `HG_STORE_GRPC_PORT` | No | `8500` | `grpc.port` |
 | `HG_STORE_REST_PORT` | No | `8520` | `server.port` |
 | `HG_STORE_DATA_PATH` | No | `/hugegraph-store/storage` | `app.data-path` |
@@ -94,34 +147,76 @@ curl http://localhost:8620/v1/partitions   # Partition assignment
 
 ### Server Variables
 
-| Variable | Required | Default | Maps To |
-|----------|----------|---------|---------|
-| `HG_SERVER_BACKEND` | Yes | — | `backend` in `hugegraph.properties` |
-| `HG_SERVER_PD_PEERS` | Yes | — | `pd.peers` |
-| `STORE_REST` | No | — | used by `wait-partition.sh` |
-| `PASSWORD` | No | — | enables auth mode |
+Unlike PD and Store, the Server entrypoint requires nothing: every variable below is optional and only the ones that are set are written into the config files. A distributed deployment still needs at least `HG_SERVER_BACKEND` and `HG_SERVER_PD_PEERS`.
+
+| Variable | Default | Maps To |
+|----------|---------|---------|
+| `HG_SERVER_BACKEND` | template value (`rocksdb`, or `hstore` in the `hugegraph/server` image) | `backend` in `conf/graphs/hugegraph.properties` |
+| `HG_SERVER_PD_PEERS` | (none) | `pd.peers` in both `hugegraph.properties` and `rest-server.properties` |
+| `HG_SERVER_USE_PD` | `false` | `usePD` in `rest-server.properties` |
+| `HG_SERVER_CLUSTER` | `hg-test` | `cluster` in `rest-server.properties` |
+| `HG_SERVER_REST_URL` | `http://0.0.0.0:8080` (set in the image) | `restserver.url` |
+| `HG_SERVER_MIN_FREE_MEMORY` | `64` (MB) | `restserver.min_free_memory` |
+| `HG_SERVER_INIT_STORE_ENABLED` | `true` | `init_store.enabled`, set `false` for PD/HStore deployments where the storage side owns the metadata |
+| `HG_SERVER_AUTH_TOKEN_SECRET` | generated when `PASSWORD` is set | `auth.token_secret` in both files, must be at least 32 bytes |
+| `HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET` | `false` | when `true`, refuses to start if `PASSWORD` is set without `HG_SERVER_AUTH_TOKEN_SECRET` |
+| `PASSWORD` | (none) | `auth.admin_pa`, and runs `bin/enable-auth.sh` to turn auth mode on |
+| `PRELOAD` | (none) | `true` preloads the sample graph from `scripts/example.groovy` |
+| `JAVA_OPTS` | set in the image | passed to `bin/start-hugegraph.sh -j` |
+| `STORE_REST` | `store:8520` | Store REST endpoint that `wait-partition.sh` polls, hstore backend only |
+| `HG_SERVER_PD_REST_ENDPOINT` | derived by rewriting `:8686` to `:8620` in `pd.peers` | PD REST peers that `wait-storage.sh` polls |
+| `PD_AUTH_USER` / `PD_AUTH_PASSWORD` | `store` / `admin` | credentials `wait-storage.sh` uses against the PD REST API |
+| `WAIT_PARTITION_TIMEOUT_S` | `120` | how long `wait-partition.sh` waits for partition assignment |
+
+`wait-storage.sh` waits up to 300 seconds for a store in state `Up`. That budget is fixed in the script and cannot be raised from the environment.
 
 > **Deprecated aliases**: `BACKEND` → `HG_SERVER_BACKEND`, `PD_PEERS` → `HG_SERVER_PD_PEERS`
 
+`HG_SERVER_INIT_STORE_ENABLED` accepts only the spellings `HugeConfig` accepts, case-insensitively: `y`, `t`, `yes`, `on`, `true`, `n`, `f`, `no`, `off`, `false`. Anything else, `0` and `1` included, aborts the entrypoint.
+
+The entrypoint writes `docker/init_complete` after a successful initialization and skips re-initialization on later startups, but still re-runs `bin/init-store.sh` so a disabled one revalidates its configuration on every start.
+
+### Compose Variables
+
+These are read by the Compose files rather than by the entrypoints:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `HUGEGRAPH_VERSION` | `latest` | Image tag for Server, PD, and Store |
+| `HUGEGRAPH_PULL_POLICY` | `missing` | `pull_policy` for those images, use `never` to keep locally built ones |
+| `HUBBLE_IMAGE` | `hugegraph/hubble:latest` | Hubble image, selected independently of `HUGEGRAPH_VERSION` |
+| `HUBBLE_PULL_POLICY` | `missing` | `pull_policy` for the Hubble image |
+| `HUBBLE_PUBLISH_HOST` | `127.0.0.1` | Host interface Hubble's `8088` is published on |
+| `HUGEGRAPH_ADMIN_PASSWORD` | (none) | Passed to the Server as `PASSWORD` |
+| `HUGEGRAPH_AUTH_TOKEN_SECRET` | (none) | Passed to the Server as `HG_SERVER_AUTH_TOKEN_SECRET` |
+
 ## Port Reference
 
-| Service | Host Port | Purpose |
-|---------|-----------|---------|
-| pd0 | 8620 | REST API |
-| pd0 | 8686 | gRPC |
-| pd1 | 8621 | REST API |
-| pd1 | 8687 | gRPC |
-| pd2 | 8622 | REST API |
-| pd2 | 8688 | gRPC |
-| store0 | 8500 | gRPC |
-| store0 | 8520 | REST API |
-| store1 | 8501 | gRPC |
-| store1 | 8521 | REST API |
-| store2 | 8502 | gRPC |
-| store2 | 8522 | REST API |
-| server0 | 8080 | Graph API |
-| server1 | 8081 | Graph API |
-| server2 | 8082 | Graph API |
+Ports published by the 3-node cluster:
+
+| Service | Host Port | Container Port | Purpose |
+|---------|-----------|----------------|---------|
+| pd0 | 8620 | 8620 | REST API |
+| pd0 | 8686 | 8686 | gRPC |
+| pd1 | 8621 | 8620 | REST API |
+| pd1 | 8687 | 8686 | gRPC |
+| pd2 | 8622 | 8620 | REST API |
+| pd2 | 8688 | 8686 | gRPC |
+| store0 | 8500 | 8500 | gRPC |
+| store0 | 8510 | 8510 | Raft |
+| store0 | 8520 | 8520 | REST API |
+| store1 | 8501 | 8500 | gRPC |
+| store1 | 8511 | 8510 | Raft |
+| store1 | 8521 | 8520 | REST API |
+| store2 | 8502 | 8500 | gRPC |
+| store2 | 8512 | 8510 | Raft |
+| store2 | 8522 | 8520 | REST API |
+| server0 | 8080 | 8080 | Graph API |
+| server1 | 8081 | 8080 | Graph API |
+| server2 | 8082 | 8080 | Graph API |
+| hubble | 8088 | 8088 | Hubble UI, bound to `127.0.0.1` by default |
+
+The standalone topology publishes only `8080` and `8088`. The minimal HStore topology publishes `8620` (PD REST), `8520` (Store REST), `8080`, and `8088`. PD Raft uses `8610` inside the network and is not published by any topology.
 
 ## Troubleshooting
 
@@ -133,7 +228,9 @@ curl http://localhost:8620/v1/partitions   # Partition assignment
 
 4. **Connection refused**: Ensure `HG_*` environment variables use container hostnames (`pd0`, `store0`) instead of `127.0.0.1`.
 
-**Viewing runtime logs**: Use `docker logs <container-name>` (e.g. `docker logs hg-pd0`) to view logs directly without exec-ing into the container.
+5. **Data survives a restart when you did not expect it to**: `docker compose down` keeps the named volumes. Use `docker compose down -v` to delete the topology's data as well.
+
+**Viewing runtime logs**: Use `docker logs <container-name>` (e.g. `docker logs hg-pd0`) to view logs directly without exec-ing into the container. The standalone `hugegraph/hugegraph` image sets `STDOUT_MODE=true`, so its server log goes to the container stdout. The `hugegraph/server` (HStore) image does not, so `docker logs` on a Server of an HStore topology shows only the entrypoint output; read `logs/hugegraph-server.log` inside the container for the rest.
 
 ## Container Supervision & Health Checks
 
@@ -145,7 +242,7 @@ Previously, all three Docker entrypoints ended with `tail -f /dev/null`, which k
 
 The entrypoints now supervise Java directly:
 
-- **PD and Store containers**: the entrypoint passes `-d false` to the startup script, which `exec`s Java directly. The container process IS the Java process — when Java exits (crash or clean shutdown), the container exits immediately and Docker's restart policy fires.
+- **PD and Store containers**: the entrypoint passes `-d false` to the startup script, which `exec`s Java directly. The container process IS the Java process: when Java exits (crash or clean shutdown), the container exits immediately and Docker's restart policy fires.
 - **Server container**: the entrypoint uses `tail --pid=$PID -f /dev/null` to block until Java exits. A `SIGTERM`/`SIGINT` trap forwards `docker stop` signals to Java and waits for clean shutdown (exits 0). If Java crashes, the entrypoint exits 1 so the restart policy fires.
 - `dumb-init` (PID 1 in all images) forwards signals from Docker to the entrypoint process.
 
@@ -155,9 +252,11 @@ All four Docker images now include a `HEALTHCHECK` instruction. `docker ps` show
 
 | Image | Health endpoint | Port | Parameters |
 |-------|-----------------|------|------------|
-| `hugegraph/hugegraph` (server) | `GET /versions` | 8080 | `--interval=15s --timeout=10s --start-period=90s --retries=3` |
-| `hugegraph/hugegraph-hstore` | `GET /versions` | 8080 | same |
-| `hugegraph/hugegraph-pd` | `GET /v1/health` | 8620 | same |
-| `hugegraph/hugegraph-store` | `GET /v1/health` | 8520 | same |
+| `hugegraph/hugegraph` (standalone RocksDB Server) | `GET /versions` | 8080 | `--interval=15s --timeout=10s --start-period=90s --retries=3` |
+| `hugegraph/server` (HStore Server) | `GET /versions` | 8080 | same |
+| `hugegraph/pd` | `GET /v1/health` | 8620 | same |
+| `hugegraph/store` | `GET /v1/health` | 8520 | same |
+
+The Compose files define their own health checks on top of these, so `--wait` and `depends_on: condition: service_healthy` work without relying on the image defaults. Those Compose checks use a shorter start period (30 to 120 seconds depending on the service and topology) and more retries.
 
 > **Note**: The `-m true` flag (cron-based monitor) in `start-hugegraph.sh` is for VM/bare-metal deployments only. It is not installed or used in Docker images. Docker users should rely on the built-in `HEALTHCHECK` and Docker's restart policy instead.

--- a/content/en/docs/quickstart/hugegraph/hugegraph-server.md
+++ b/content/en/docs/quickstart/hugegraph/hugegraph-server.md
@@ -24,7 +24,11 @@ The `hugegraph-server` module in HugeGraph 1.7.0 is compiled with Java 11. Runni
 
 **Before continuing, run `java -version` to confirm your JDK version.**
 
-> Java 8 is no longer supported starting from 1.7.0.
+> Java 8 is no longer supported starting from 1.7.0. `bin/hugegraph-server.sh` refuses to start on anything older than Java 11.
+
+> The security check is on by default and installs `HugeSecurityManager`, which needs Java 11 to 23. JDK 24 removed the Security Manager ([JEP 486](https://openjdk.org/jeps/486)), so on Java 24 or later you must start the service with the check disabled: `bin/start-hugegraph.sh -s false`.
+
+> Building from source also needs Maven 3.5.0 or later.
 
 ## 3 Deploy
 
@@ -57,18 +61,24 @@ If you use Docker Desktop, you can set the options as follows:
 > **Note**: The Docker Compose files use bridge networking (`hg-net`) and work on Linux and Mac (Docker Desktop). For the 3-node distributed cluster on Mac (Docker Desktop), allocate at least **12 GB** of memory (Settings → Resources → Memory). On Linux, Docker uses host memory directly.
 
 If you want a single, unified setup for multiple HugeGraph services, you can use `docker compose`.
-Two compose files are available in the [`docker/`](https://github.com/apache/hugegraph/tree/master/docker) directory:
+Four compose files are available in the [`docker/`](https://github.com/apache/hugegraph/tree/master/docker) directory:
 
-- **Single-node quickstart** (pre-built images): `docker/docker-compose.yml`
-- **Single-node dev build** (build from source): `docker/docker-compose.dev.yml`
+| Topology | Compose file | Services |
+|---|---|---|
+| Standalone (start here) | `docker-compose.yml` | 1 RocksDB Server + 1 Hubble |
+| Minimal HStore | `docker-compose-hstore.yml` | 1 PD + 1 Store + 1 Server + 1 Hubble |
+| HA reference | `docker-compose-3pd-3store-3server.yml` | 3 PD + 3 Store + 3 Server + 1 Hubble |
+| Source build override for the minimal HStore topology | `docker-compose.dev.yml` | (used together with `docker-compose-hstore.yml`) |
 
 ```bash
 cd hugegraph/docker
 # Keep the version aligned with the latest release, for example 1.x.0
-HUGEGRAPH_VERSION=1.7.0 docker compose up -d
+HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose.yml up -d --wait
 ```
 
-To enable authentication, add `PASSWORD=xxx` to the service environment in the compose file or pass `-e PASSWORD=xxx` to `docker run`.
+The standalone topology publishes the Server on port `8080` and Hubble on `127.0.0.1:8088`. `HUGEGRAPH_VERSION` selects the Server, PD, and Store image tags; Hubble is selected separately with `HUBBLE_IMAGE`.
+
+The compose files read the administrator password from `HUGEGRAPH_ADMIN_PASSWORD` and the JWT secret from `HUGEGRAPH_AUTH_TOKEN_SECRET`, normally kept in a `docker/.env` file. A non-empty `HUGEGRAPH_ADMIN_PASSWORD` turns authentication on, and Hubble detects that mode by itself. With plain `docker run`, pass `-e PASSWORD=xxx` instead.
 
 See [docker/README.md](https://github.com/apache/hugegraph/blob/master/docker/README.md) for the full setup guide.
 
@@ -129,6 +139,13 @@ A successful build includes the following line:
 ```
 
 After a successful build, the generated distribution is the `*hugegraph-*.tar.gz` file in the repository root.
+
+The default build bundles the `rocksdb`, `hbase`, and `hstore` backend modules, and records them in the `backends` option of the `backend.properties` resource inside the `hugegraph-dist` jar. To build a smaller distribution that carries RocksDB only, add `-Drocksdb-only`:
+
+```bash
+mvn package -DskipTests -ntp -Drocksdb-only
+```
+
 > [!DETAILS]- Outdated tools
 > #### 3.4 One-click deployment (Outdated)
 >
@@ -189,7 +206,6 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 > ```properties
 > backend=hstore
 > serializer=binary
-> task.scheduler_type=distributed
 >
 > # PD service address, multiple PD addresses are separated by commas, configure PD's RPC port
 > pd.peers=127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688
@@ -204,17 +220,20 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 > serializer=binary
 > store=hugegraph
 >
-> # Specify the task scheduler (for versions 1.7.0 and earlier, hstore storage is required)
-> task.scheduler_type=distributed
->
 > # pd config
 > pd.peers=127.0.0.1:8686
 > ```
+>
+> A ready-made template for this backend ships as `conf/graphs/hstore.properties.template`. Copy it over `conf/graphs/hugegraph.properties` and adjust `pd.peers`.
+>
+> The task scheduler is picked from the backend, so `task.scheduler_type` does not need to be set. `hstore` uses the distributed scheduler and every other backend uses the local one. The key is still accepted for upgrade compatibility, but it is ignored and logs a warning.
 >
 > Then enable PD discovery in `rest-server.properties` (required for every HugeGraph-Server node):
 >
 > ```properties
 > usePD=true
+> # load the hugegraph.properties above from the graphs directory; the source default is false
+> graph.load_from_local_config=true
 >
 > # notice: must have this conf in 1.7.0
 > pd.peers=127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688
@@ -273,6 +292,8 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 > bin/init-store.sh
 > ```
 >
+> PD and Store own the metadata and the store for the `hstore` backend, so `init-store` skips graphs configured with it. Running it still creates the built-in `admin` account when authentication is on. In a deployment where the storage side already holds that account, set `init_store.enabled=false` in `rest-server.properties` to skip the whole step, which is what the Docker HStore topologies do.
+>
 > Start the Server:
 >
 > ```bash
@@ -288,7 +309,7 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 > Verify that the service is started properly:
 >
 > ```bash
-> curl http://localhost:8081/graphs
+> curl http://localhost:8081/graphspaces/DEFAULT/graphs
 > # Should return: {"graphs":["hugegraph"]}
 > ```
 >
@@ -307,16 +328,26 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 >
 > ```bash
 > cd hugegraph/docker
-> HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+> HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d --wait
 > ```
 >
 > Services communicate via container hostnames on the `hg-net` bridge network. Configuration is injected via environment variables:
 >
 > ```yaml
-> # Server configuration
+> # Server configuration, shared by server0, server1 and server2
 > HG_SERVER_BACKEND: hstore
 > HG_SERVER_PD_PEERS: pd0:8686,pd1:8686,pd2:8686
+> HG_SERVER_CLUSTER: hg
+> HG_SERVER_USE_PD: "true"
+> HG_SERVER_MIN_FREE_MEMORY: "0"
+> HG_SERVER_INIT_STORE_ENABLED: "false"
+> HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET: "true"
+> STORE_REST: store0:8520
+> # per node, for example on server0
+> HG_SERVER_REST_URL: http://server0:8080
 > ```
+>
+> Because this topology sets `HG_SERVER_REQUIRE_AUTH_TOKEN_SECRET: "true"`, the Servers refuse to start when a password is supplied without a shared JWT secret. Put both `HUGEGRAPH_ADMIN_PASSWORD` and `HUGEGRAPH_AUTH_TOKEN_SECRET` in `docker/.env` before starting it. The full variable reference is in the [Docker Cluster guide](/docs/guides/hugegraph-docker-cluster/).
 >
 > Verify the cluster:
 > ```bash
@@ -352,8 +383,9 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 >
 > ```bash
 > bin/start-hugegraph.sh
-> Starting HugeGraphServer...
+> Starting HugeGraphServer in daemon mode...
 > Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)....OK
+> Started [pid 21614]
 > ```
 >
 > **ToplingDB (Beta)**: As a high-performance alternative to RocksDB, please refer to the configuration guide: [ToplingDB Quick Start]({{< ref path="/blog/hugegraph/toplingdb/toplingdb-quick-start.md" lang="en">}})
@@ -390,8 +422,9 @@ Since the configuration (hugegraph.properties) and startup steps required by var
 >
 > ```bash
 > bin/start-hugegraph.sh
-> Starting HugeGraphServer...
+> Starting HugeGraphServer in daemon mode...
 > Connecting to HugeGraphServer (http://127.0.0.1:8080/graphs)....OK
+> Started [pid 21614]
 > ```
 >
 #### 5.1.4 Create an example graph when startup
@@ -413,6 +446,22 @@ And use the RESTful API to request `HugeGraphServer` and get the following resul
 
 This indicates the successful creation of the sample graph.
 
+#### 5.1.5 Startup script options
+
+`bin/start-hugegraph.sh` accepts the following options. Every one of them takes a value, so write `-d false`, not a bare `-d`.
+
+| Option | Values | Default | Purpose |
+|---|---|---|---|
+| `-d` | `true`, `false` | `true` | Daemon mode. With `-d false` the script stays in the foreground and forwards `SIGTERM`/`SIGINT` to the server. |
+| `-g` | `zgc` or `ZGC` | omit for G1GC | Garbage collector to use. Only ZGC is accepted, any other value aborts the startup. ZGC needs Java 11 or later. |
+| `-m` | `true`, `false` | `false` | Install the cron-based monitor task (`bin/start-monitor.sh`). For VM and bare-metal deployments only. |
+| `-p` | `true`, `false` | `false` | Preload the sample graph, as in 5.1.4. |
+| `-s` | `true`, `false` | `true` | Run with the security check (`HugeSecurityManager`) enabled. It requires Java 11 to 23 and a readable `conf/java-security.properties`. |
+| `-j` | JVM options | empty | Extra JVM options appended to the server command line. |
+| `-t` | seconds | `30` | How long to wait for the service to answer before reporting a failed startup. |
+| `-y` | `true`, `false` | `false` | Enable the OpenTelemetry agent for traces. |
+
+`bin/stop-hugegraph.sh` accepts `-m true|false` (default `true`), which controls whether the cron monitor task is removed along with the service.
 
 ### 5.2 Use Docker to startup
 
@@ -440,12 +489,12 @@ Set the environment variable `PRELOAD=true` when starting Docker so that sample 
           - PRELOAD=true
           - PASSWORD=xxx
         volumes:
-          - /path/to/yourscript:/hugegraph/scripts/example.groovy
+          - /path/to/yourscript:/hugegraph-server/scripts/example.groovy
         ports:
           - 8080:8080
     ```
 
-    Use `docker-compose up -d` to start the container.
+    Use `docker compose up -d` to start the container.
 
 And use the RESTful API to request `HugeGraphServer` and get the following result:
 


### PR DESCRIPTION
Syncs the `hugegraph-dist` surface (startup scripts, `conf/` templates, Docker images and compose topologies, IDEA run configs) with `apache/hugegraph` master at `36811483a`. Both `content/en/docs/` and `content/cn/docs/` are updated.

| page | what was wrong | what changed | source (file:line on master) |
|---|---|---|---|
| quickstart/hugegraph/hugegraph-server.md | HStore setup told users to set `task.scheduler_type=distributed` (twice) | Removed the key from both snippets, added a note that the scheduler is picked from the backend and that the key is ignored with a warning | hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java:230 |
| quickstart/hugegraph/hugegraph-server.md | "Two compose files are available", `docker-compose.dev.yml` described as a single-node dev build | Table of all four files with their real services; `.dev.yml` documented as the source-build overlay for the minimal HStore topology | docker/README.md:13, docker/README.md:278, docker/docker-compose.dev.yml:18 |
| quickstart/hugegraph/hugegraph-server.md | Compose auth described as "add `PASSWORD=xxx` to the compose file" | Compose reads `HUGEGRAPH_ADMIN_PASSWORD` and `HUGEGRAPH_AUTH_TOKEN_SECRET` (usually from `docker/.env`); `docker run` still uses `-e PASSWORD` | docker/docker-compose.yml:34, docker/README.md:24 |
| quickstart/hugegraph/hugegraph-server.md | Preload script mounted at `/hugegraph/scripts/example.groovy` | Corrected to `/hugegraph-server/scripts/example.groovy` (image WORKDIR) | hugegraph-server/Dockerfile:47, hugegraph-server/hugegraph-dist/docker/README.md:53 |
| quickstart/hugegraph/hugegraph-server.md | `curl http://localhost:8081/graphs` given as the readiness check | Corrected to `/graphspaces/DEFAULT/graphs`; there is no bare `/graphs` resource | hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/profile/GraphsAPI.java:72 |
| quickstart/hugegraph/hugegraph-server.md | Sample output read `Starting HugeGraphServer...` | Corrected to `Starting HugeGraphServer in daemon mode...` plus the `Started [pid N]` line | hugegraph-server/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh:103, bin/util.sh:381 |
| quickstart/hugegraph/hugegraph-server.md | Only `-p true` was documented; no reference for the other startup flags | New 5.1.5 section with all eight `start-hugegraph.sh` options and their defaults, plus `stop-hugegraph.sh -m`; notes that `-g` accepts only ZGC | bin/start-hugegraph.sh:50, bin/hugegraph-server.sh:137, bin/stop-hugegraph.sh:20 |
| quickstart/hugegraph/hugegraph-server.md | Java requirement stated as "11 or later" with no upper bound | Added that the default security check needs Java 11 to 23 (JDK 24 removed the Security Manager, use `-s false`), that the script rejects anything below 11, and that the build needs Maven 3.5.0+ | bin/hugegraph-server.sh:66, bin/hugegraph-server.sh:70, pom.xml:241 |
| quickstart/hugegraph/hugegraph-server.md | Source build had no mention of the backend selection | Documented `-Drocksdb-only` and the default `rocksdb, hbase, hstore` backend set | hugegraph-server/hugegraph-dist/pom.xml:38, hugegraph-server/hugegraph-dist/pom.xml:294 |
| quickstart/hugegraph/hugegraph-server.md | HStore section listed only two Server env vars; `init-store` step and `graph.load_from_local_config` were inconsistent between en and cn | Full Server env block from the HA compose file, the `hstore.properties.template` pointer, the `init_store.enabled` behaviour, and `graph.load_from_local_config=true` in the en page too | docker/docker-compose-3pd-3store-3server.yml:62, hugegraph-dist/src/main/java/org/apache/hugegraph/cmd/InitStore.java:86, ServerOptions.java:355 |
| config/config-guide.md | `gremlin-server.yaml` snippet was missing `GlobalMasterInfo` and had `DateUtil` in the wrong position | Snippet now matches the shipped file line for line | hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml:43 |
| config/config-guide.md | `#gremlinserver.url=http://127.0.0.1:8182` did not match the template | Matches the template (`127.0.0.1:8182`), with a note that the scheme is prepended when missing | conf/rest-server.properties:6, ServerOptions.java:117 |
| config/config-guide.md | `hugegraph.properties` snippet was missing `vertex.cache_type`, `edge.cache_type`, `vertex.default_label`, `serializer.buffer_max_capacity`, the HBase partition keys, the raft deprecation note and the whole memory block; carried a stale ikanalyzer download note | Snippet now matches `conf/graphs/hugegraph.properties` key by key | conf/graphs/hugegraph.properties:1 |
| config/config-guide.md | Option list omitted the newly uncommented cache and task keys; RocksDB path defaults undocumented | Added `vertex.cache_type`/`edge.cache_type` (`l1`/`l2`, default `l2`), the task keys and analyzer list, and the `rocksdb-data/data` and `rocksdb-data/wal` defaults | CoreOptions.java:540, CoreOptions.java:603, hugegraph-rocksdb/.../RocksDBOptions.java:58 |
| config/config-guide.md | "HugeGraphServer does not support distributed deployment"; GremlinServer default given as `localhost:8182` | Removed the stale claim, defaults corrected to `127.0.0.1:8182` | conf/gremlin-server.yaml:18, ServerOptions.java:117 |
| config/config-guide.md | Multi-graph startup output showed a `/graphspaces/DEFAULT/graphs` probe URL | The script probes `$REST_SERVER_URL/graphs` and prints "in daemon mode" | bin/start-hugegraph.sh:113 |
| guides/hugegraph-docker-cluster.md | "Three compose files"; `.dev.yml` described as a single-node dev build; no `.env` / auth section; HStore and Hubble topologies missing | Four-file table, image naming, a new Authentication Environment section, a Minimal HStore quickstart, and the dev overlay usage | docker/README.md:13, docker/README.md:24, docker/docker-compose-hstore.yml:1, docker/docker-compose.dev.yml:18 |
| guides/hugegraph-docker-cluster.md | PD alias list omitted `PD_INITIAL_STORE_LIST` | Added, plus the mapping rule and the exit-code-2 behaviour for missing required vars | hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh:47, :22 |
| guides/hugegraph-docker-cluster.md | Server table listed 4 vars, two of them marked required | Full table of 16 Server vars with defaults and target keys, the accepted `HG_SERVER_INIT_STORE_ENABLED` spellings, the init marker, and a new Compose Variables table | hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh:90, bin/wait-storage.sh:38, bin/wait-partition.sh:22, docker/docker-compose.yml:29 |
| guides/hugegraph-docker-cluster.md | Port table missed the Store raft ports and Hubble, and did not distinguish host from container ports | Added container ports, store raft ports, Hubble `8088`, and what each topology publishes | docker/docker-compose-3pd-3store-3server.yml:110, :162, :236 |
| guides/hugegraph-docker-cluster.md | Health-check table used non-existent image names (`hugegraph/hugegraph-pd`, `hugegraph/hugegraph-store`, `hugegraph/hugegraph-hstore`) | Corrected to `hugegraph/pd`, `hugegraph/store`, `hugegraph/server`, plus a note that Compose defines its own checks | docker/README.md:263, docker/docker-compose-hstore.yml:30 |
| guides/hugegraph-docker-cluster.md | "use `docker logs`" applied uniformly to all images | Noted that only the standalone image sets `STDOUT_MODE=true`, so HStore Server logs live in `logs/hugegraph-server.log`; added the `down` vs `down -v` data note | hugegraph-server/Dockerfile:45, hugegraph-server/Dockerfile-hstore:46, docker/README.md:256 |
| clients/gremlin-console.md | `:> hugegraph.traversal().V()` and `graph = hugegraph;` cannot resolve, the Server binds graphs under a graphspace-qualified name | Documented the `DEFAULT-hugegraph` / `__g_DEFAULT-hugegraph` bindings and replaced the examples with the aliased driver flow | hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java:49, :134, HugeFactory.java:85, hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh:62 |
| clients/gremlin-console.md | No mention of connecting to an auth-enabled Server, or of the sibling driver config files | Added the `username`/`password` keys and a pointer to `remote-objects.yaml` and `gremlin-driver-settings.yaml` | run-gremlin-console-smoke-test.sh:55, conf/remote-objects.yaml:17, conf/gremlin-driver-settings.yaml:17 |
| contribution-guidelines/hugegraph-server-idea-setup.md | Copy command and Log4j2 path used `hugegraph-dist/...`, which does not exist at the repo root | Corrected to `hugegraph-server/hugegraph-dist/...` | hugegraph-server/hugegraph-dist/src/assembly/static/conf, hugegraph-server/hugegraph-dist/src/main/resources/log4j2.xml |
| contribution-guidelines/hugegraph-server-idea-setup.md | `preload-topling.sh` and the ToplingDB env vars were presented as ordinary steps, but nothing ToplingDB-related exists in the repo | Marked as applying only to a build that includes ToplingDB | no `topling` match anywhere under `apache/hugegraph` master |
| contribution-guidelines/hugegraph-server-idea-setup.md | Line-anchored links to `init-store.sh#L52` and `hugegraph-server.sh#L124` pointed at the wrong lines; the relationship to the shipped entry point was unexplained | Anchors moved to `#L49` and `#L132`, and added that the script actually launches `HugeGraphServerBootstrap` around `HugeGraphServer` | bin/init-store.sh:49, bin/hugegraph-server.sh:132, bin/hugegraph-server.sh:263 |
